### PR TITLE
fix: the action buttons were not visible in the collapsible rows within the stock tabs.

### DIFF
--- a/src/components/accounting/GameStock.tsx
+++ b/src/components/accounting/GameStock.tsx
@@ -622,7 +622,7 @@ const GameStock = () => {
           title={t("Game Stocks")}
           addButton={addButton}
           filterPanel={filterPanel}
-          isActionsActive={false}
+          isActionsActive={isGameStockEnableEdit}
           isCollapsible={true}
           isToolTipEnabled={false}
           isExcel={user && [RoleEnum.MANAGER].includes(user?.role?._id)}

--- a/src/components/accounting/Stock.tsx
+++ b/src/components/accounting/Stock.tsx
@@ -627,7 +627,7 @@ const Stock = () => {
           title={t("Product Stocks")}
           addButton={addButton}
           filterPanel={filterPanel}
-          isActionsActive={false}
+          isActionsActive={isStockEnableEdit}
           isCollapsible={true}
           isToolTipEnabled={false}
           isExcel={user && [RoleEnum.MANAGER].includes(user?.role?._id)}

--- a/src/components/panelComponents/Tables/GenericTable.tsx
+++ b/src/components/panelComponents/Tables/GenericTable.tsx
@@ -670,20 +670,20 @@ const GenericTable = <T,>({
                               );
                             }
                           )}
-                          <td
-                            className={`py-2 px-4  ${
-                              rowIndex !==
-                                row?.collapsible?.collapsibleRows.length - 1 &&
-                              "border-b"
-                            }`}
-                          >
-                            {collapsibleActions &&
-                              isActionsActive &&
-                              renderActionButtons(
+                          {collapsibleActions && isActionsActive && (
+                            <td
+                              className={`py-2 px-4  ${
+                                rowIndex !==
+                                  row?.collapsible?.collapsibleRows.length - 1 &&
+                                "border-b"
+                              }`}
+                            >
+                              {renderActionButtons(
                                 { ...row, ...collapsibleRow }, //by this way we can access the main row data in the collapsible actions
                                 collapsibleActions
                               )}
-                          </td>
+                            </td>
+                          )}
                         </tr>
                       )
                     )}

--- a/src/components/stocks/DessertStocks.tsx
+++ b/src/components/stocks/DessertStocks.tsx
@@ -578,7 +578,7 @@ const DessertStock = () => {
           title={t("Dessert Stocks")}
           addButton={addButton}
           filterPanel={filterPanel}
-          isActionsActive={false}
+          isActionsActive={isDesertStockEnableEdit}
           isCollapsible={true}
           isToolTipEnabled={false}
           isExcel={user && [RoleEnum.MANAGER].includes(user?.role?._id)}


### PR DESCRIPTION
- Cem reported a bug on the /stocks page: the action buttons were not visible in the collapsible rows within the stock tabs.
- update isActionsActive state for stock components