### PR TITLE
 odeme-ekrani-filtre-dropdownuna-oyuncu-belirteci ekleme

### DIFF
--- a/src/components/orders/orderPayment/OrderPaymentModal.tsx
+++ b/src/components/orders/orderPayment/OrderPaymentModal.tsx
@@ -898,7 +898,7 @@ const OrderPaymentModal = ({
                             value: selectedActivityUser,
                             label:
                               selectedActivityUser === ""
-                                ? t("All")
+                                ? t("All Players")
                                 : selectedActivityUser,
                           }}
                           options={
@@ -909,7 +909,7 @@ const OrderPaymentModal = ({
                                   label: u,
                                 };
                               }),
-                              { value: "", label: t("All") },
+                              { value: "", label: t("All Players") },
                             ] as any
                           }
                           isMultiple={false}

--- a/src/locales/en/ translation.json
+++ b/src/locales/en/ translation.json
@@ -822,5 +822,6 @@
   "The Name field must not be left blank. The blue columns are designated for entering product details, while the orange columns are for menu item details. Fields marked with an asterisk (*) are mandatory. You can fill out either product details or menu item details independently.The Expense Type, Brand and Vendor fields allow multiple entries. When entering multiple values, separate them with commas.": "The Name field must not be left blank. The blue columns are designated for entering product details, while the orange columns are for menu item details. Fields marked with an asterisk (*) are mandatory. You can fill out either product details or menu item details independently.The Expense Type, Brand and Vendor fields allow multiple entries. When entering multiple values, separate them with commas.",
   "GeneralDeleteMessage": "will be deleted. Are you sure you want to continue?",
   "TableShort": "T",
-  "PlayerShort": "P"
+  "PlayerShort": "P",
+  "All Players": "All Players"
 }

--- a/src/locales/tr/ translation.json
+++ b/src/locales/tr/ translation.json
@@ -827,5 +827,6 @@
   "Duration": "Süre",
   "Call Count": "Çağrı Sayısı",
   "TableShort": "M",
-  "PlayerShort": "O"
+  "PlayerShort": "O",
+  "All Players": "Tüm Oyuncular"
 }


### PR DESCRIPTION
ödeme ekranında, ödenmemiş siparişler kolonunun üzerinde yer alan oyuncu seçimi dropdown menüsüne "masa mı-oyuncu mu seçiliyor" ikilemini ortadan kaldırmak için "tüm oyuncular" belirteci eklendi