### PR TITLE
fix: etkinlik masası boş form submit sorunu düzeltildi

### DIFF
--- a/src/components/panelComponents/FormElements/GenericAddEditPanel.tsx
+++ b/src/components/panelComponents/FormElements/GenericAddEditPanel.tsx
@@ -48,6 +48,7 @@ type Props<T> = {
   isCreateConfirmationDialogExist?: boolean;
   isCreateCloseActive?: boolean;
   optionalCreateButtonActive?: boolean;
+  skipValidationWhenOptionalActive?: boolean;
   isEditMode?: boolean;
   folderName?: string;
   buttonName?: string;
@@ -91,6 +92,7 @@ const GenericAddEditPanel = <T,>({
   handleUpdate,
   anotherPanel,
   optionalCreateButtonActive,
+  skipValidationWhenOptionalActive = false,
   cancelButtonLabel = "Cancel",
   submitFunction,
   additionalSubmitFunction,
@@ -323,7 +325,7 @@ const GenericAddEditPanel = <T,>({
         handleSubmit();
       }
     } else if (optionalCreateButtonActive) {
-      if (!_.isEqual(formElements, mergedInitialState) && !allRequiredFilled) {
+      if (!skipValidationWhenOptionalActive && !_.isEqual(formElements, mergedInitialState) && !allRequiredFilled) {
         toast.error(t("Please fill all required fields"));
         return;
       }

--- a/src/components/tables/TableCard.tsx
+++ b/src/components/tables/TableCard.tsx
@@ -1035,6 +1035,7 @@ export function TableCard({
           setForm={setOrderForm}
           isCreateCloseActive={false}
           optionalCreateButtonActive={orderCreateBulk?.length > 0}
+          skipValidationWhenOptionalActive={true}
           constantValues={{
             quantity: 1,
             stockLocation: table?.isOnlineSale ? 6 : selectedLocationId,
@@ -1089,6 +1090,28 @@ export function TableCard({
                   setSelectedNewOrders([]);
                   return;
                 }
+              } else if (
+                !orderForm?.item &&
+                (orderForm?.activityTableName || orderForm?.activityPlayer) &&
+                orderCreateBulk.length > 0
+              ) {
+                // If item is empty but activity table/player info is filled and there are orders in bulk, create the bulk orders
+                createMultipleOrder({
+                  orders: orderCreateBulk.map((orderCreateBulkItem) => {
+                    return {
+                      ...orderCreateBulkItem,
+                      tableDate: table ? new Date(table?.date) : new Date(),
+                    };
+                  }),
+                  table: table,
+                });
+                setOrderForm(initialOrderForm);
+                setOrderCreateBulk([]);
+                setSelectedNewOrders([]);
+                if (table.type === TableTypes.TAKEOUT) {
+                  setIsTableCardCreateOrderDialogOpen(false);
+                }
+                return;
               }
               createMultipleOrder({
                 orders: orderCreateBulk.map((orderCreateBulkItem) => {


### PR DESCRIPTION
fix: etkinlik masası sipariş alırken boş form submit sorunu düzeltildi

Etkinlik masalarında sipariş eklerken kullanıcı deneyimini iyileştirmek
için yapılan değişiklikler:

- Ürün alanı boş iken masa-oyuncu bilgisi dolu olduğunda "Oluştur"
  butonuna basıldığında, halihazırdaki sipariş listesindeki siparişlerin
  oluşturulması sağlandı

- GenericAddEditPanel'e skipValidationWhenOptionalActive prop'u eklendi
  Bu prop sayesinde sipariş listesi dolu olduğunda form validasyonu
  atlanarak kullanıcının listedeki siparişleri oluşturması sağlandı

- TableCard submitFunction'ında ürün alanı boş ama masa-oyuncu bilgisi
  dolu olduğunda bulk siparişlerin oluşturulması için kontrol eklendi

Kullanıcı artık her sipariş için masa-oyuncu numarasını tekrar girmek
zorunda kalmadan, son ekleme sonrası boş formla "Oluştur" butonuna
basarak tüm siparişleri gönderebilir.

Değiştirilen dosyalar:
- src/components/tables/TableCard.tsx
- src/components/panelComponents/FormElements/GenericAddEditPanel.tsx
