### PR TITLE
sipariş transferinde tüm ürünlerin görüntülenmesi

### DIFF
--- a/src/components/orders/orderPayment/orderList/OrderSelect.tsx
+++ b/src/components/orders/orderPayment/orderList/OrderSelect.tsx
@@ -23,8 +23,11 @@ const OrderSelect = ({ tableOrders }: Props) => {
     setIsSelectAll,
     selectedDiscount,
     isProductDivideOpen,
+    isTransferProductOpen,
   } = useOrderContext();
-  let filteredOrders = tableOrders?.filter((order) => !order.discount);
+  let filteredOrders = isTransferProductOpen
+    ? tableOrders
+    : tableOrders?.filter((order) => !order.discount);
   if (selectedDiscount) {
     filteredOrders = filteredOrders.filter((order) =>
       categories


### PR DESCRIPTION
…rün böl' - 'ürün bazlı 1/n' butonlarına basınca render edilen orderselect komponentinde listelenen sipariş listesinde üç butona tıklandığında da aynı liste görüntüleniyordu.

'ürün böl' - 'ürün bazlı 1/n' butonlarına basınca indirimli ürünlerin listelenmesi istenmiyordu, orası öyle kaldı

ama sipariş transferi'ne basınca indirimli ürünlerin görüntülenmesi gerekiyordu

bu sebeple OrderSelect.tsx komponentine useOrderContext'te halihazırda var olan isTransferProductOpen alanı da çekildi ve sipariş transferinde burada görüntülenen listeye 'eğer bu koşul aktif ise' filteredOrders'a tüm listenin atanması sağlandı