### PR TITLE
zayi ürün girme hatası fix(BE'si de var)

### DIFF
--- a/src/components/stocks/LossProduct.tsx
+++ b/src/components/stocks/LossProduct.tsx
@@ -524,6 +524,7 @@ const LossProduct = () => {
                 stockLocation: Number(orderForm?.stockLocation),
                 stockNote: StockHistoryStatusEnum.LOSSPRODUCT,
                 tableDate: new Date(),
+                isLossProduct: true,
               });
             }
             setOrderForm(initialOrderForm);

--- a/src/pages/Tables.tsx
+++ b/src/pages/Tables.tsx
@@ -2382,6 +2382,7 @@ const Tables = () => {
                 stockLocation: Number(orderForm?.stockLocation),
                 stockNote: StockHistoryStatusEnum.LOSSPRODUCT,
                 tableDate: new Date(),
+                isLossProduct: true,
               });
             }
             setOrderForm(initialOrderForm);


### PR DESCRIPTION
son geliştirmede sipariş oluşturmak için /orders'a oluşturma isteği atmak için masayı zorunlu kılmıştık ama  zayi ürün girerken de createOrder endpointine istek attığımız için, masası olmadığından dolayı hata veriyordu, islossproduct flagi eklenerek sorun çözüldü