### PR TITLE
Sipariş ekranında stoktan fazla ürün miktarı girildiğinde her ürün için uyarı penceresi gösterilmesi

### DIFF
--- a/src/components/orders/orderPayment/OrderPaymentModal.tsx
+++ b/src/components/orders/orderPayment/OrderPaymentModal.tsx
@@ -42,7 +42,7 @@ import {
   unlockBodyScroll,
 } from "../../../utils/bodyScrollLock";
 import { formatDate } from "../../../utils/dateUtil";
-import { getItem, getMenuItemSubText } from "../../../utils/getItem";
+import { getItem, getMenuItemSubText, menuItemHasDecrementStock } from "../../../utils/getItem";
 import { printTableReceipt } from "../../../utils/printReceipt";
 import { ConfirmationDialog } from "../../common/ConfirmationDialog";
 import { GenericButton } from "../../common/GenericButton";
@@ -922,10 +922,7 @@ const OrderPaymentModal = ({
           const stockQuantity = menuItem
             ? menuItemStockQuantity(menuItem, orderForm.stockLocation)
             : null;
-          const hasDecrementStock = menuItem?.itemProduction?.some(
-            (production) => production.isDecrementStock
-          );
-          if (!hasDecrementStock) {
+          if (!menuItemHasDecrementStock(menuItem)) {
             return false;
           }
           return !stockQuantity || stockQuantity < orderForm.quantity;

--- a/src/components/orders/orderPayment/OrderPaymentModal.tsx
+++ b/src/components/orders/orderPayment/OrderPaymentModal.tsx
@@ -919,13 +919,13 @@ const OrderPaymentModal = ({
         }}
         isConfirmationDialogRequired={() => {
           const menuItem = items?.find((item) => item?._id === orderForm.item);
-          const category = categories?.find(
-            (category) => category?._id === menuItem?.category
-          );
           const stockQuantity = menuItem
             ? menuItemStockQuantity(menuItem, orderForm.stockLocation)
             : null;
-          if (!category?.isOnlineOrder) {
+          const hasDecrementStock = menuItem?.itemProduction?.some(
+            (production) => production.isDecrementStock
+          );
+          if (!hasDecrementStock) {
             return false;
           }
           return !stockQuantity || stockQuantity < orderForm.quantity;

--- a/src/components/tables/TableCard.tsx
+++ b/src/components/tables/TableCard.tsx
@@ -47,7 +47,7 @@ import {
   useReopenTableMutation,
   useTableMutations,
 } from "../../utils/api/table";
-import { getItem, getMenuItemSubText } from "../../utils/getItem";
+import { getItem, getMenuItemSubText, menuItemHasDecrementStock } from "../../utils/getItem";
 import { getDuration } from "../../utils/time";
 import { CardAction } from "../common/CardAction";
 import { ConfirmationDialog } from "../common/ConfirmationDialog";
@@ -1225,10 +1225,7 @@ export function TableCard({
             const stockQuantity = menuItem
               ? menuItemStockQuantity(menuItem, orderForm.stockLocation)
               : null;
-            const hasDecrementStock = menuItem?.itemProduction?.some(
-              (production) => production.isDecrementStock
-            );
-            if (!hasDecrementStock) {
+            if (!menuItemHasDecrementStock(menuItem)) {
               return false;
             }
             return !stockQuantity || stockQuantity < orderForm.quantity;

--- a/src/components/tables/TableCard.tsx
+++ b/src/components/tables/TableCard.tsx
@@ -1222,13 +1222,13 @@ export function TableCard({
             const menuItem = menuItems?.find(
               (item) => item._id === orderForm.item
             );
-            const category = categories?.find(
-              (category) => category._id === menuItem?.category
-            );
             const stockQuantity = menuItem
               ? menuItemStockQuantity(menuItem, orderForm.stockLocation)
               : null;
-            if (!category?.isOnlineOrder) {
+            const hasDecrementStock = menuItem?.itemProduction?.some(
+              (production) => production.isDecrementStock
+            );
+            if (!hasDecrementStock) {
               return false;
             }
             return !stockQuantity || stockQuantity < orderForm.quantity;

--- a/src/pages/Tables.tsx
+++ b/src/pages/Tables.tsx
@@ -2232,13 +2232,13 @@ const Tables = () => {
             const menuItem = menuItems?.find(
               (item) => item._id === orderForm.item
             );
-            const category = categories?.find(
-              (category) => category._id === menuItem?.category
-            );
             const stockQuantity = menuItem
               ? menuItemStockQuantity(menuItem, orderForm.stockLocation)
               : null;
-            if (!category?.isOnlineOrder) {
+            const hasDecrementStock = menuItem?.itemProduction?.some(
+              (production) => production.isDecrementStock
+            );
+            if (!hasDecrementStock) {
               return false;
             }
             return !stockQuantity || stockQuantity < orderForm.quantity;
@@ -2447,13 +2447,13 @@ const Tables = () => {
             const menuItem = menuItems?.find(
               (item) => item._id === orderForm.item
             );
-            const category = categories?.find(
-              (category) => category._id === menuItem?.category
-            );
             const stockQuantity = menuItem
               ? menuItemStockQuantity(menuItem, orderForm.stockLocation)
               : null;
-            if (!category?.isOnlineOrder) {
+            const hasDecrementStock = menuItem?.itemProduction?.some(
+              (production) => production.isDecrementStock
+            );
+            if (!hasDecrementStock) {
               return false;
             }
             return !stockQuantity || stockQuantity < orderForm.quantity;

--- a/src/pages/Tables.tsx
+++ b/src/pages/Tables.tsx
@@ -63,7 +63,7 @@ import {
 } from "../utils/api/table";
 import { MinimalUser } from "../utils/api/user";
 import { formatDate, isToday, parseDate } from "../utils/dateUtil";
-import { getItem, getMenuItemSubText } from "../utils/getItem";
+import { getItem, getMenuItemSubText, menuItemHasDecrementStock } from "../utils/getItem";
 import { sortTable } from "../utils/sort";
 const Tables = () => {
   const { t } = useTranslation();
@@ -2235,10 +2235,7 @@ const Tables = () => {
             const stockQuantity = menuItem
               ? menuItemStockQuantity(menuItem, orderForm.stockLocation)
               : null;
-            const hasDecrementStock = menuItem?.itemProduction?.some(
-              (production) => production.isDecrementStock
-            );
-            if (!hasDecrementStock) {
+            if (!menuItemHasDecrementStock(menuItem)) {
               return false;
             }
             return !stockQuantity || stockQuantity < orderForm.quantity;
@@ -2450,10 +2447,7 @@ const Tables = () => {
             const stockQuantity = menuItem
               ? menuItemStockQuantity(menuItem, orderForm.stockLocation)
               : null;
-            const hasDecrementStock = menuItem?.itemProduction?.some(
-              (production) => production.isDecrementStock
-            );
-            if (!hasDecrementStock) {
+            if (!menuItemHasDecrementStock(menuItem)) {
               return false;
             }
             return !stockQuantity || stockQuantity < orderForm.quantity;

--- a/src/utils/getItem.ts
+++ b/src/utils/getItem.ts
@@ -46,3 +46,9 @@ export function getMenuItemSubText(
 
   return subProductNames.join("|||");
 }
+
+export function menuItemHasDecrementStock(
+  item: MenuItem | undefined
+): boolean {
+  return item?.itemProduction?.some((p) => p.isDecrementStock) ?? false;
+}


### PR DESCRIPTION
Sipariş ekranında stoktan fazla ürün miktarı girildiğinde oyunlar için uyarı veriyor ama tatlı-içeceklerde vs direkt ekliyordu, stok eksiye düşmemesi için her ürün için uyarı penceresi gösterilmesi sağlandı