### PR TITLE
Kafe web sitesinde "Aylık Etkinlik Takvimi" göstermek için yapılan geliştirmeler(BE'si de var)

### DIFF
--- a/src/components/activities/MonthlyCafeActivities.tsx
+++ b/src/components/activities/MonthlyCafeActivities.tsx
@@ -1,0 +1,349 @@
+import { useMemo, useRef, useState } from "react";
+import { useTranslation } from "react-i18next";
+import { HiOutlineTrash } from "react-icons/hi2";
+import { FiEdit } from "react-icons/fi";
+import { toast } from "react-toastify";
+import { AxiosHeaders } from "axios";
+import { ConfirmationDialog } from "../common/ConfirmationDialog";
+import Loading from "../common/Loading";
+import GenericTable from "../panelComponents/Tables/GenericTable";
+import { postWithHeader } from "../../utils/api";
+import {
+  useGetMonthlyActivities,
+  useMonthlyActivityMutations,
+} from "../../utils/api/cafeActivity";
+import { MonthlyActivity } from "../../types";
+
+const MonthlyCafeActivities = () => {
+  const { t } = useTranslation();
+  const monthlyActivities = useGetMonthlyActivities();
+  const { createMonthlyActivity, updateMonthlyActivity, deleteMonthlyActivity } =
+    useMonthlyActivityMutations();
+
+  // Add modal
+  const [isAddModalOpen, setIsAddModalOpen] = useState(false);
+  const [isSubmitting, setIsSubmitting] = useState(false);
+  const [previewUrl, setPreviewUrl] = useState<string | null>(null);
+  const [pendingFile, setPendingFile] = useState<File | null>(null);
+  const [monthInfo, setMonthInfo] = useState("");
+  const fileInputRef = useRef<HTMLInputElement>(null);
+
+  // Edit modal
+  const [isEditModalOpen, setIsEditModalOpen] = useState(false);
+  const [rowToEdit, setRowToEdit] = useState<MonthlyActivity | null>(null);
+  const [editMonthInfo, setEditMonthInfo] = useState("");
+  const [editPreviewUrl, setEditPreviewUrl] = useState<string | null>(null);
+  const [editPendingFile, setEditPendingFile] = useState<File | null>(null);
+  const editFileInputRef = useRef<HTMLInputElement>(null);
+
+  // Delete
+  const [rowToAction, setRowToAction] = useState<MonthlyActivity | undefined>();
+  const [isDeleteDialogOpen, setIsDeleteDialogOpen] = useState(false);
+
+  const handleFileChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+    const file = e.target.files?.[0];
+    if (!file) return;
+    if (previewUrl) URL.revokeObjectURL(previewUrl);
+    setPendingFile(file);
+    setPreviewUrl(URL.createObjectURL(file));
+  };
+
+  const handleEditFileChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+    const file = e.target.files?.[0];
+    if (!file) return;
+    if (editPendingFile && editPreviewUrl) URL.revokeObjectURL(editPreviewUrl);
+    setEditPendingFile(file);
+    setEditPreviewUrl(URL.createObjectURL(file));
+  };
+
+  const handleModalClose = () => {
+    if (previewUrl) URL.revokeObjectURL(previewUrl);
+    setPreviewUrl(null);
+    setPendingFile(null);
+    setMonthInfo("");
+    setIsAddModalOpen(false);
+    if (fileInputRef.current) fileInputRef.current.value = "";
+  };
+
+  const handleEditModalClose = () => {
+    if (editPendingFile && editPreviewUrl) URL.revokeObjectURL(editPreviewUrl);
+    setEditPreviewUrl(null);
+    setEditPendingFile(null);
+    setRowToEdit(null);
+    setIsEditModalOpen(false);
+    if (editFileInputRef.current) editFileInputRef.current.value = "";
+  };
+
+  const handleSubmit = async () => {
+    if (!pendingFile) {
+      toast.error(t("Please select an image"));
+      return;
+    }
+    setIsSubmitting(true);
+    try {
+      const formData = new FormData();
+      formData.append("file", pendingFile);
+      formData.append("filename", pendingFile.name);
+      formData.append("foldername", "monthly-activities");
+      const { url } = await postWithHeader<FormData, { url: string }>({
+        path: "/asset/upload",
+        payload: formData,
+        headers: new AxiosHeaders({ "Content-Type": "multipart/form-data" }),
+      });
+      createMonthlyActivity(
+        { imageUrl: url, monthInfo: monthInfo || undefined },
+        {
+          onSuccess: () => {
+            toast.success(t("Monthly activity added"));
+            handleModalClose();
+          },
+          onError: () => toast.error(t("Monthly activity could not be added")),
+        }
+      );
+    } catch {
+      toast.error(t("Image upload failed"));
+    } finally {
+      setIsSubmitting(false);
+    }
+  };
+
+  const handleEditSubmit = async () => {
+    if (!rowToEdit) return;
+    setIsSubmitting(true);
+    try {
+      let imageUrl = rowToEdit.imageUrl;
+      if (editPendingFile) {
+        const formData = new FormData();
+        formData.append("file", editPendingFile);
+        formData.append("filename", editPendingFile.name);
+        formData.append("foldername", "monthly-activities");
+        const { url } = await postWithHeader<FormData, { url: string }>({
+          path: "/asset/upload",
+          payload: formData,
+          headers: new AxiosHeaders({ "Content-Type": "multipart/form-data" }),
+        });
+        imageUrl = url;
+      }
+      updateMonthlyActivity(
+        {
+          id: rowToEdit._id,
+          updates: {
+            imageUrl,
+            monthInfo: editMonthInfo || undefined,
+          },
+        },
+        {
+          onSuccess: () => {
+            toast.success(t("Monthly activity updated"));
+            handleEditModalClose();
+          },
+          onError: () => toast.error(t("Monthly activity could not be updated")),
+        }
+      );
+    } catch {
+      toast.error(t("Image upload failed"));
+    } finally {
+      setIsSubmitting(false);
+    }
+  };
+
+  const columns = useMemo(
+    () => [
+      { key: t("Image"), isSortable: false },
+      { key: t("Month Info"), isSortable: true },
+      { key: t("Actions"), isSortable: false },
+    ],
+    [t]
+  );
+
+  const rowKeys = useMemo(
+    () => [
+      {
+        key: "imageUrl",
+        node: (row: MonthlyActivity) =>
+          row.imageUrl ? (
+            <img
+              src={row.imageUrl}
+              alt="monthly activity"
+              className="w-16 h-16 object-cover rounded"
+            />
+          ) : (
+            "-"
+          ),
+      },
+      {
+        key: "monthInfo",
+        node: (row: MonthlyActivity) => row.monthInfo || "-",
+      },
+    ],
+    [t]
+  );
+
+  const addButton = useMemo(
+    () => ({
+      name: t("Add Monthly Calendar"),
+      isModal: true,
+      modal: isAddModalOpen ? (
+        <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/50">
+          <div className="bg-white rounded-xl shadow-xl p-6 w-full max-w-sm flex flex-col gap-4">
+            <h2 className="text-lg font-semibold">{t("Add Monthly Calendar")}</h2>
+            <div
+              className="border-2 border-dashed border-gray-300 rounded-lg flex flex-col items-center justify-center cursor-pointer hover:border-blue-400 transition-colors overflow-hidden"
+              style={{ minHeight: 180 }}
+              onClick={() => fileInputRef.current?.click()}
+            >
+              {previewUrl ? (
+                <img src={previewUrl} alt="preview" className="w-full h-full object-contain max-h-64" />
+              ) : (
+                <span className="text-gray-400 text-sm select-none py-12">{t("Click to select image")}</span>
+              )}
+            </div>
+            <input ref={fileInputRef} type="file" accept="image/*" className="hidden" onChange={handleFileChange} />
+            <div className="flex flex-col gap-1">
+              <label className="text-sm font-medium text-gray-700">{t("Month Info")}</label>
+              <input
+                type="text"
+                value={monthInfo}
+                onChange={(e) => setMonthInfo(e.target.value)}
+                placeholder={t("April")}
+                className="border border-gray-300 rounded-lg px-3 py-2 text-sm focus:outline-none focus:border-blue-400"
+              />
+            </div>
+            <div className="flex gap-2 justify-end">
+              <button onClick={handleModalClose} className="px-4 py-2 rounded-lg border border-gray-300 text-sm hover:bg-gray-50">
+                {t("Cancel")}
+              </button>
+              <button
+                onClick={handleSubmit}
+                disabled={!pendingFile}
+                className="px-4 py-2 rounded-lg bg-blue-500 text-white text-sm hover:bg-blue-600 disabled:opacity-40"
+              >
+                {t("Save")}
+              </button>
+            </div>
+          </div>
+        </div>
+      ) : null,
+      isModalOpen: isAddModalOpen,
+      setIsModal: (val: boolean) => {
+        if (!val) handleModalClose();
+        else setIsAddModalOpen(true);
+      },
+      isPath: false,
+      icon: null,
+      className: "bg-blue-500 hover:text-blue-500 hover:border-blue-500",
+    }),
+    [t, isAddModalOpen, previewUrl, pendingFile, monthInfo]
+  );
+
+  const actions = useMemo(
+    () => [
+      {
+        name: t("Edit"),
+        icon: <FiEdit />,
+        setRow: (row: MonthlyActivity) => {
+          setRowToEdit(row);
+          setEditMonthInfo(row.monthInfo ?? "");
+          setEditPreviewUrl(row.imageUrl ?? null);
+          setEditPendingFile(null);
+        },
+        modal: isEditModalOpen && rowToEdit ? (
+          <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/50">
+            <div className="bg-white rounded-xl shadow-xl p-6 w-full max-w-sm flex flex-col gap-4">
+              <h2 className="text-lg font-semibold">{t("Edit Monthly Calendar")}</h2>
+              <div
+                className="border-2 border-dashed border-gray-300 rounded-lg flex flex-col items-center justify-center cursor-pointer hover:border-blue-400 transition-colors overflow-hidden"
+                style={{ minHeight: 180 }}
+                onClick={() => editFileInputRef.current?.click()}
+              >
+                {editPreviewUrl ? (
+                  <img src={editPreviewUrl} alt="preview" className="w-full h-full object-contain max-h-64" />
+                ) : (
+                  <span className="text-gray-400 text-sm select-none py-12">{t("Click to select image")}</span>
+                )}
+              </div>
+              <input ref={editFileInputRef} type="file" accept="image/*" className="hidden" onChange={handleEditFileChange} />
+              <div className="flex flex-col gap-1">
+                <label className="text-sm font-medium text-gray-700">{t("Month Info")}</label>
+                <input
+                  type="text"
+                  value={editMonthInfo}
+                  onChange={(e) => setEditMonthInfo(e.target.value)}
+                  placeholder={t("April")}
+                  className="border border-gray-300 rounded-lg px-3 py-2 text-sm focus:outline-none focus:border-blue-400"
+                />
+              </div>
+              <div className="flex gap-2 justify-end">
+                <button onClick={handleEditModalClose} className="px-4 py-2 rounded-lg border border-gray-300 text-sm hover:bg-gray-50">
+                  {t("Cancel")}
+                </button>
+                <button
+                  onClick={handleEditSubmit}
+                  className="px-4 py-2 rounded-lg bg-blue-500 text-white text-sm hover:bg-blue-600"
+                >
+                  {t("Save")}
+                </button>
+              </div>
+            </div>
+          </div>
+        ) : null,
+        className: "text-blue-500 cursor-pointer text-2xl",
+        isModal: true,
+        isModalOpen: isEditModalOpen,
+        setIsModal: setIsEditModalOpen,
+        isPath: false,
+      },
+      {
+        name: t("Delete"),
+        icon: <HiOutlineTrash />,
+        setRow: setRowToAction,
+        modal: rowToAction ? (
+          <ConfirmationDialog
+            isOpen={isDeleteDialogOpen}
+            close={() => setIsDeleteDialogOpen(false)}
+            confirm={() => {
+              deleteMonthlyActivity(rowToAction._id);
+              setIsDeleteDialogOpen(false);
+            }}
+            title={t("Delete Monthly Activity")}
+            text={t("Monthly Activity Calendar Delete Message", { monthInfo: rowToAction.monthInfo ?? "" })}
+          />
+        ) : null,
+        className: "text-red-500 cursor-pointer text-2xl",
+        isModal: true,
+        isModalOpen: isDeleteDialogOpen,
+        setIsModal: setIsDeleteDialogOpen,
+        isPath: false,
+      },
+    ],
+    [
+      t,
+      rowToAction, isDeleteDialogOpen, deleteMonthlyActivity,
+      rowToEdit, isEditModalOpen, editMonthInfo, editPreviewUrl, editPendingFile,
+    ]
+  );
+
+  return (
+    <>
+      {isSubmitting && <Loading />}
+      <div className="w-[98%] mx-auto mt-6 mb-2 px-2">
+        <p className="text-sm text-gray-500 italic">
+          {t("Monthly Activity Calendar Information Message")}
+        </p>
+      </div>
+      <div className="w-[98%] mx-auto my-4">
+        <GenericTable
+          rowKeys={rowKeys}
+          actions={actions}
+          isActionsActive={true}
+          columns={columns}
+          rows={[...(monthlyActivities ?? [])].sort((a, b) => b._id - a._id)}
+          title={t("Monthly Cafe Activities")}
+          addButton={addButton}
+        />
+      </div>
+    </>
+  );
+};
+
+export default MonthlyCafeActivities;

--- a/src/components/activities/MonthlyCafeActivities.tsx
+++ b/src/components/activities/MonthlyCafeActivities.tsx
@@ -97,7 +97,6 @@ const MonthlyCafeActivities = () => {
             toast.success(t("Monthly activity added"));
             handleModalClose();
           },
-          onError: () => toast.error(t("Monthly activity could not be added")),
         }
       );
     } catch {
@@ -109,6 +108,13 @@ const MonthlyCafeActivities = () => {
 
   const handleEditSubmit = async () => {
     if (!rowToEdit) return;
+    const hasChanges =
+      editPendingFile !== null ||
+      editMonthInfo !== (rowToEdit.monthInfo ?? "");
+    if (!hasChanges) {
+      handleEditModalClose();
+      return;
+    }
     setIsSubmitting(true);
     try {
       let imageUrl = rowToEdit.imageUrl;
@@ -137,7 +143,6 @@ const MonthlyCafeActivities = () => {
             toast.success(t("Monthly activity updated"));
             handleEditModalClose();
           },
-          onError: () => toast.error(t("Monthly activity could not be updated")),
         }
       );
     } catch {
@@ -154,6 +159,11 @@ const MonthlyCafeActivities = () => {
       { key: t("Actions"), isSortable: false },
     ],
     [t]
+  );
+
+  const sortedMonthlyActivities = useMemo(
+    () => [...(monthlyActivities ?? [])].sort((a, b) => b._id - a._id),
+    [monthlyActivities]
   );
 
   const rowKeys = useMemo(
@@ -337,7 +347,7 @@ const MonthlyCafeActivities = () => {
           actions={actions}
           isActionsActive={true}
           columns={columns}
-          rows={[...(monthlyActivities ?? [])].sort((a, b) => b._id - a._id)}
+          rows={sortedMonthlyActivities}
           title={t("Monthly Cafe Activities")}
           addButton={addButton}
         />

--- a/src/components/common/Loading.tsx
+++ b/src/components/common/Loading.tsx
@@ -1,8 +1,11 @@
+import { useTranslation } from "react-i18next";
+
 const Loading = () => {
+  const { t } = useTranslation();
   return (
-    <div className="fixed inset-0 w-full h-full z-50">
+    <div className="fixed inset-0 w-full h-full z-[9999]">
       -
-      <div className="absolute inset-0 w-full h-full z-50 opacity-50 bg-black text-white">
+      <div className="absolute inset-0 w-full h-full z-[9999] opacity-50 bg-black text-white">
         <div className="flex justify-center w-full h-full items-center">
           <svg
             className="animate-spin -ml-1 mr-3 h-5 w-5 text-white"
@@ -24,7 +27,7 @@ const Loading = () => {
               d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4zm2 5.291A7.962 7.962 0 014 12H0c0 3.042 1.135 5.824 3 7.938l3-2.647z"
             ></path>
           </svg>
-          <h1 className="text-2xl">Loading...</h1>
+          <h1 className="text-2xl">{t("Loading")}</h1>
         </div>
       </div>
     </div>

--- a/src/locales/en/translation.json
+++ b/src/locales/en/translation.json
@@ -1524,5 +1524,6 @@
   "Monthly activity added": "Monthly activity added",
   "Monthly activity could not be added" : "Monthly activity could not be added",
   "Image upload failed" : "Image upload failed",
-  "Monthly activity updated" : "Monthly activity updated"
+  "Monthly activity updated" : "Monthly activity updated",
+  "Logs" : "System Logs"
 }

--- a/src/locales/en/translation.json
+++ b/src/locales/en/translation.json
@@ -1523,5 +1523,6 @@
   "Cafe Activities" : "Cafe Activities",
   "Monthly activity added": "Monthly activity added",
   "Monthly activity could not be added" : "Monthly activity could not be added",
-  "Image upload failed" : "Image upload failed"
+  "Image upload failed" : "Image upload failed",
+  "Monthly activity updated" : "Monthly activity updated"
 }

--- a/src/locales/en/translation.json
+++ b/src/locales/en/translation.json
@@ -1512,5 +1512,16 @@
   "Requested Games": "Requested Games",
   "Last Requested At": "Last Requested At",
   "Number of Concurrent Requests": "Num of Concurrent Requests",
-  "Redis cache cleared successfully": "Redis cache cleared successfully"
+  "Redis cache cleared successfully": "Redis cache cleared successfully",
+  "Monthly Cafe Activities" : "Monthly Cafe Activities",
+  "Monthly Activity Calendar Information Message" : "Images uploaded here will be displayed on davinciboardgame.com.",
+  "Add Monthly Calendar" : "Add Monthly Calendar",
+  "Month Info" : "Month Info",
+  "Delete Monthly Activity" : "Delete Monthly Activity",
+  "Monthly Activity Calendar Delete Message" : "{{monthInfo}} month's event poster will be permanently deleted. Are you sure?",
+  "Click to select image" : "Click to select image",
+  "Cafe Activities" : "Cafe Activities",
+  "Monthly activity added": "Monthly activity added",
+  "Monthly activity could not be added" : "Monthly activity could not be added",
+  "Image upload failed" : "Image upload failed"
 }

--- a/src/locales/tr/translation.json
+++ b/src/locales/tr/translation.json
@@ -1522,5 +1522,16 @@
   "Last Requested At": "Son Talep Tarihi",
   "File Name": "Dosya İsmi",
   "Number of Concurrent Requests": "Eşzamanlı İstek Sayısı",
-  "Redis cache cleared successfully": "Redis cache başarıyla sıfırlandı"
+  "Redis cache cleared successfully": "Redis cache başarıyla sıfırlandı",
+  "Monthly Cafe Activities" : "Aylık Etkinlik Takvimi",
+  "Monthly Activity Calendar Information Message" : "Buraya yüklenen resimler davinciboardgame.com sitesinde görüntülenecektir.",
+  "Add Monthly Calendar" : "Aylık Etkinlik Takvimi Ekle",
+  "Month Info" : "Ay Bilgisi",
+  "Delete Monthly Activity" : "Aylık Etkinlik Sil",
+  "Monthly Activity Calendar Delete Message" : "{{monthInfo}} ayı etkinlik afişi kalıcı olarak silinecek. Emin misiniz?",
+  "Click to select image" : "Resim Seçmek için Tıklayınız",
+  "Cafe Activities": "Kafedeki Etkinlikler",
+  "Monthly activity added": "Aylık etkinlik takvimi eklendi",
+  "Monthly activity could not be added" : "Aylık etkinlik takvimi eklenemedi",
+  "Image upload failed" : "Resim yüklenemedi"
 }

--- a/src/locales/tr/translation.json
+++ b/src/locales/tr/translation.json
@@ -1533,5 +1533,6 @@
   "Cafe Activities": "Kafedeki Etkinlikler",
   "Monthly activity added": "Aylık etkinlik takvimi eklendi",
   "Monthly activity could not be added" : "Aylık etkinlik takvimi eklenemedi",
-  "Image upload failed" : "Resim yüklenemedi"
+  "Image upload failed" : "Resim yüklenemedi",
+  "Monthly activity updated" : "Aylık etkinlik takvimi güncellendi"
 }

--- a/src/locales/tr/translation.json
+++ b/src/locales/tr/translation.json
@@ -1534,5 +1534,6 @@
   "Monthly activity added": "Aylık etkinlik takvimi eklendi",
   "Monthly activity could not be added" : "Aylık etkinlik takvimi eklenemedi",
   "Image upload failed" : "Resim yüklenemedi",
-  "Monthly activity updated" : "Aylık etkinlik takvimi güncellendi"
+  "Monthly activity updated" : "Aylık etkinlik takvimi güncellendi",
+  "Logs" : "Sistem Logları"
 }

--- a/src/navigation/constants.ts
+++ b/src/navigation/constants.ts
@@ -6,7 +6,7 @@ import Analytics from "../pages/Analytics";
 import Brand from "../pages/Brand";
 import BulkProductAdding from "../pages/BulkProductAdding";
 import ButtonCalls from "../pages/ButtonCalls";
-import CafeActivity from "../pages/CafeActivity";
+import Activities, { ActivitiesPageTabs } from "../pages/Activities";
 import Check from "../pages/Check";
 import Checklist from "../pages/Checklist";
 import Checklists, { ChecklistTabs } from "../pages/Checklists";
@@ -258,12 +258,6 @@ export const allRoutes: {
     isOnSidebar: false,
     tabs: OrderDataTabs,
   },
-  // {
-  //   name: "Ikas Pick Up",
-  //   path: Routes.IkasPickUp,
-  //   element: IkasPickUp,
-  //   isOnSidebar: true,
-  // },
   {
     name: "Shopify Pick Up",
     path: Routes.ShopifyPickUp,
@@ -285,8 +279,9 @@ export const allRoutes: {
       {
         name: "Activities",
         path: Routes.Activities,
-        element: CafeActivity,
+        element: Activities,
         isOnSidebar: true,
+        tabs: ActivitiesPageTabs,
       },
       {
         name: "Memberships",
@@ -311,8 +306,9 @@ export const allRoutes: {
   {
     name: "Activities",
     path: Routes.Activities,
-    element: CafeActivity,
+    element: Activities,
     isOnSidebar: false,
+    tabs: ActivitiesPageTabs,
   },
   {
     name: "Memberships",

--- a/src/pages/Activities.tsx
+++ b/src/pages/Activities.tsx
@@ -1,0 +1,48 @@
+import { useState } from "react";
+import { MdEventNote, MdOutlineCalendarMonth } from "react-icons/md";
+import MonthlyCafeActivities from "../components/activities/MonthlyCafeActivities";
+import { Header } from "../components/header/Header";
+import UnifiedTabPanel from "../components/panelComponents/TabPanel/UnifiedTabPanel";
+import { useGeneralContext } from "../context/General.context";
+import { ActivitiesPageTabEnum } from "../types";
+import CafeActivity from "./CafeActivity";
+
+export const ActivitiesPageTabs = [
+  {
+    number: ActivitiesPageTabEnum.CAFE_ACTIVITIES,
+    label: "Cafe Activities",
+    icon: <MdEventNote className="text-lg font-thin" />,
+    content: <CafeActivity />,
+    isDisabled: false,
+  },
+  {
+    number: ActivitiesPageTabEnum.MONTHLY_CAFE_ACTIVITIES,
+    label: "Monthly Cafe Activities",
+    icon: <MdOutlineCalendarMonth className="text-lg font-thin" />,
+    content: <MonthlyCafeActivities />,
+    isDisabled: false,
+  },
+];
+
+export default function Activities() {
+  const [activeTab, setActiveTab] = useState<number>(0);
+  const { setCurrentPage, setSearchQuery } = useGeneralContext();
+
+  return (
+    <>
+      <Header showLocationSelector={false} />
+      <div className="flex flex-col gap-2 mt-5">
+        <UnifiedTabPanel
+          tabs={ActivitiesPageTabs}
+          activeTab={activeTab}
+          setActiveTab={setActiveTab}
+          additionalOpenAction={() => {
+            setCurrentPage(1);
+            setSearchQuery("");
+          }}
+          allowOrientationToggle={true}
+        />
+      </div>
+    </>
+  );
+}

--- a/src/pages/CafeActivity.tsx
+++ b/src/pages/CafeActivity.tsx
@@ -4,7 +4,6 @@ import { FiEdit } from "react-icons/fi";
 import { HiOutlineTrash } from "react-icons/hi2";
 import { CheckSwitch } from "../components/common/CheckSwitch";
 import { ConfirmationDialog } from "../components/common/ConfirmationDialog";
-import { Header } from "../components/header/Header";
 import GenericAddEditPanel from "../components/panelComponents/FormElements/GenericAddEditPanel";
 import GenericTable from "../components/panelComponents/Tables/GenericTable";
 import SwitchButton from "../components/panelComponents/common/SwitchButton";
@@ -332,21 +331,18 @@ const CafeActivity = () => {
   );
 
   return (
-    <>
-      <Header showLocationSelector={false} />
-      <div className="w-[98%] mx-auto my-10">
-        <GenericTable
-          rowKeys={rowKeys}
-          actions={actions}
-          isActionsActive={true}
-          columns={columns}
-          filters={filters}
-          rows={rows}
-          title={t("Activities")}
-          addButton={addButton}
-        />
-      </div>
-    </>
+    <div className="w-[98%] mx-auto my-10">
+      <GenericTable
+        rowKeys={rowKeys}
+        actions={actions}
+        isActionsActive={true}
+        columns={columns}
+        filters={filters}
+        rows={rows}
+        title={t("Activities")}
+        addButton={addButton}
+      />
+    </div>
   );
 };
 

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -957,6 +957,11 @@ export type CafeActivity = {
   contact: string;
   isCompleted?: boolean;
 };
+export type MonthlyActivity = {
+  _id: number;
+  imageUrl: string;
+  monthInfo?: string;
+};
 export type IkasCustomer = {
   id: string;
   firstName: string;
@@ -1466,6 +1471,11 @@ export enum LogsPageTabEnum {
   WEBHOOK_LOGS,
   PRICE_COMPARE_LOGS,
   CONCURRENCY_LOGS,
+}
+
+export enum ActivitiesPageTabEnum {
+  CAFE_ACTIVITIES,
+  MONTHLY_CAFE_ACTIVITIES,
 }
 
 export type ConcurrentRequest = {

--- a/src/utils/api/cafeActivity.ts
+++ b/src/utils/api/cafeActivity.ts
@@ -1,4 +1,4 @@
-import { CafeActivity } from "../../types/index";
+import { CafeActivity, MonthlyActivity } from "../../types";
 import { Paths, useGetList, useMutationApi } from "./factory";
 
 export function useCafeActivityMutations() {
@@ -15,4 +15,20 @@ export function useCafeActivityMutations() {
 
 export function useGetCafeActivitys() {
   return useGetList<CafeActivity>(Paths.CafeActivity);
+}
+
+export function useMonthlyActivityMutations() {
+  const {
+    createItem: createMonthlyActivity,
+    updateItem: updateMonthlyActivity,
+    deleteItem: deleteMonthlyActivity,
+  } = useMutationApi<MonthlyActivity>({
+    baseQuery: Paths.MonthlyActivity,
+  });
+
+  return { createMonthlyActivity, updateMonthlyActivity, deleteMonthlyActivity };
+}
+
+export function useGetMonthlyActivities() {
+  return useGetList<MonthlyActivity>(Paths.MonthlyActivity);
 }

--- a/src/utils/api/factory.ts
+++ b/src/utils/api/factory.ts
@@ -17,6 +17,7 @@ export const Paths = {
   Checkout: "/checkout",
   Games: "/games",
   CafeActivity: "/visits/cafe-activity",
+  MonthlyActivity: "/monthly-activity",
   Gameplays: "/gameplays",
   GameplayTime: "/gameplaytime",
   Users: "/users",


### PR DESCRIPTION
- Aylık etkinlik takvimini yüklemek için /activities adresinde görüntülenmek üzere "MonthlyCafeActivities" sayfası oluşturuldu.
- /activity sayfası tablı hale getirildi, kafede yapılacak etkinlikler ve aylık etkinlikler ayrı tablarda gösteriliyor
- Loading.tsx'de i18n kullanımına geçildi ve z-indexi artırıldı
- constants.ts'e tablı yapı için gerekli ekleme yapıldı (ayrıca comment olarak duran ikas pick up bloğu kaldırıldı )
- api'de yeni oluşturduğumuz endpoint için factory.ts'e ekleme yapıldı.
- api ile iletişim için yeni bir servis dosyası eklenmedi, cafeActivity.ts'e eklemeler yapıldı