### PR TITLE
User.dto'ya cafeId eklenmesi(BE'si de var)

### DIFF
--- a/src/pages/Users.tsx
+++ b/src/pages/Users.tsx
@@ -46,6 +46,7 @@ interface TableUser {
   birthDate: Date;
   imageUrl: string;
   workType: WorkType;
+  cafeId?: string;
   userGames: [
     {
       game: number;
@@ -122,6 +123,13 @@ export default function Users() {
         required: false,
       },
       {
+        type: InputTypes.TEXT,
+        formKey: "cafeId",
+        label: t("Cafe ID"),
+        placeholder: t("Cafe ID"),
+        required: false,
+      },
+      {
         type: InputTypes.SELECT,
         formKey: "role",
         label: t("Role"),
@@ -147,8 +155,8 @@ export default function Users() {
     () => [
       { key: "name", type: FormKeyTypeEnum.STRING },
       { key: "fullName", type: FormKeyTypeEnum.STRING },
-
       { key: "role", type: FormKeyTypeEnum.STRING },
+      { key: "cafeId", type: FormKeyTypeEnum.STRING },
       { key: "imageUrl", type: FormKeyTypeEnum.STRING },
     ],
     []

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -235,6 +235,7 @@ export type User = {
   _id: string;
   name: string;
   fullName: string;
+  cafeId?: string;
   active: boolean;
   role: Role;
   jobStartDate: Date;


### PR DESCRIPTION
Yeni oluşturulan kullanıcının cafeId'sinin oluşturulma esnasında atanması için backenddeki user.dto'ya cafeId eklenmişti; bu tarafta da ilgili fieldin setlenmesi için /users sayfasındaki edit-create modallarına cafeId giriş alanı eklendi ve index.ts'deki ilgili tip tanımına ekleme yapıldı