### PR TITLE
/points adresindeki Users/Consumer puan geçmişi sayfalarından tahsilat tablosuna doğrudan yönlendirme

### DIFF
--- a/src/components/panelComponents/TabPanel/TabPanel.tsx
+++ b/src/components/panelComponents/TabPanel/TabPanel.tsx
@@ -68,6 +68,9 @@ const TabPanel: React.FC<Props> = ({
   };
   useEffect(() => {
     additionalOpenAction?.();
+  }, [activeTab]);
+
+  useEffect(() => {
     if (tabsRef.current[activeTab] && containerRef.current) {
       const activeTabElement = tabsRef.current[activeTab];
       if (activeTabElement) {

--- a/src/components/points/ConsumerPointHistory.tsx
+++ b/src/components/points/ConsumerPointHistory.tsx
@@ -167,7 +167,7 @@ const ConsumerPointHistoryComponent = () => {
       {
         key: "tableId",
         className: "min-w-32 pr-1",
-        node: (row: PointHistory) => {
+        node: (row: PointHistory & { formattedDate: string; date: string }) => {
           if (!row.tableId) return <p></p>;
           return (
             <p
@@ -175,7 +175,7 @@ const ConsumerPointHistoryComponent = () => {
               onClick={(e) => {
                 e.stopPropagation();
                 window.open(
-                  `/order-datas?tab=${OrderDataTabEnum.COLLECTIONS}&search=${row.tableId}&resetDateFilter=true`,
+                  `/order-datas?tab=${OrderDataTabEnum.COLLECTIONS}&search=${row.tableId}&date=${row.date}`,
                   "_blank"
                 );
               }}

--- a/src/components/points/ConsumerPointHistory.tsx
+++ b/src/components/points/ConsumerPointHistory.tsx
@@ -1,14 +1,12 @@
 import { format } from "date-fns";
-import { useMemo, useState } from "react";
+import { useMemo } from "react";
 import { useTranslation } from "react-i18next";
 import { useFilterContext } from "../../context/Filter.context";
 import { useGeneralContext } from "../../context/General.context";
-import { PointHistory, pointHistoryStatuses, PointHistoryStatusEnum } from "../../types";
+import { OrderDataTabEnum, PointHistory, pointHistoryStatuses, PointHistoryStatusEnum } from "../../types";
 import { useGetConsumersWithFullNames } from "../../utils/api/consumer";
 import { useGetPointHistories } from "../../utils/api/pointHistory";
 import { formatAsLocalDate } from "../../utils/format";
-import { useFormattedCollectionData } from "../../hooks/useFormattedCollectionData";
-import CollectionDetailsModal from "./CollectionDetailsModal";
 import GenericTable from "../panelComponents/Tables/GenericTable";
 import SwitchButton from "../panelComponents/common/SwitchButton";
 import { InputTypes } from "../panelComponents/shared/types";
@@ -28,13 +26,6 @@ const ConsumerPointHistoryComponent = () => {
   });
   const consumers = useGetConsumersWithFullNames();
   const pad = useMemo(() => (num: number) => num < 10 ? `0${num}` : num, []);
-
-  // Modal states for collection details
-  const [isCollectionModalOpen, setIsCollectionModalOpen] = useState(false);
-  const [selectedTableId, setSelectedTableId] = useState<number | undefined>(undefined);
-  const [selectedCollectionId, setSelectedCollectionId] = useState<number | undefined>(undefined);
-
-  const formattedCollectionData = useFormattedCollectionData(selectedTableId, selectedCollectionId);
 
   const rows = useMemo(() => {
     return pointHistoriesPayload?.data
@@ -170,27 +161,29 @@ const ConsumerPointHistoryComponent = () => {
             row.status === PointHistoryStatusEnum.COLLECTIONCREATED ||
             row.status === PointHistoryStatusEnum.COLLECTIONCANCELLED;
           if (!isCollectionStatus || !row.collectionId) return <p></p>;
-          const hasTableId = row.tableId != null;
-          return (
-            <p
-              className={`text-blue-500 underline w-fit ${hasTableId ? "cursor-pointer hover:text-blue-700" : "opacity-50 pointer-events-none"}`}
-              onClick={(e) => {
-                e.stopPropagation();
-                if (hasTableId) {
-                  setSelectedTableId(row.tableId);
-                  setSelectedCollectionId(row.collectionId);
-                  setIsCollectionModalOpen(true);
-                }
-              }}
-            >
-              {row.collectionId}
-            </p>
-          );
-        }
+          return <p>{row.collectionId}</p>;
+        },
       },
       {
         key: "tableId",
         className: "min-w-32 pr-1",
+        node: (row: PointHistory) => {
+          if (!row.tableId) return <p></p>;
+          return (
+            <p
+              className="text-blue-500 underline cursor-pointer hover:text-blue-700 w-fit"
+              onClick={(e) => {
+                e.stopPropagation();
+                window.open(
+                  `/order-datas?tab=${OrderDataTabEnum.COLLECTIONS}&search=${row.tableId}&resetDateFilter=true`,
+                  "_blank"
+                );
+              }}
+            >
+              {row.tableId}
+            </p>
+          );
+        },
       },
       {
         key: "oldAmount",
@@ -223,7 +216,7 @@ const ConsumerPointHistoryComponent = () => {
         },
       },
     ],
-    [t, setSelectedTableId, setSelectedCollectionId, setIsCollectionModalOpen]
+    [t]
   );
 
   const filters = useMemo(
@@ -317,18 +310,7 @@ const ConsumerPointHistoryComponent = () => {
       />
     </div>
 
-    {formattedCollectionData && (
-      <CollectionDetailsModal
-        isOpen={isCollectionModalOpen}
-        onClose={() => {
-          setIsCollectionModalOpen(false);
-          setSelectedTableId(undefined);
-          setSelectedCollectionId(undefined);
-        }}
-        collectionData={formattedCollectionData}
-      />
-    )}
-    </>
+</>
   );
 };
 

--- a/src/components/points/ConsumerPointHistory.tsx
+++ b/src/components/points/ConsumerPointHistory.tsx
@@ -1,14 +1,12 @@
 import { format } from "date-fns";
-import { useMemo, useState } from "react";
+import { useMemo } from "react";
 import { useTranslation } from "react-i18next";
 import { useFilterContext } from "../../context/Filter.context";
 import { useGeneralContext } from "../../context/General.context";
-import { PointHistory, pointHistoryStatuses, PointHistoryStatusEnum } from "../../types";
+import { OrderDataTabEnum, PointHistory, pointHistoryStatuses, PointHistoryStatusEnum } from "../../types";
 import { useGetConsumersWithFullNames } from "../../utils/api/consumer";
 import { useGetPointHistories } from "../../utils/api/pointHistory";
 import { formatAsLocalDate } from "../../utils/format";
-import { useFormattedCollectionData } from "../../hooks/useFormattedCollectionData";
-import CollectionDetailsModal from "./CollectionDetailsModal";
 import GenericTable from "../panelComponents/Tables/GenericTable";
 import SwitchButton from "../panelComponents/common/SwitchButton";
 import { InputTypes } from "../panelComponents/shared/types";
@@ -28,13 +26,6 @@ const ConsumerPointHistoryComponent = () => {
   });
   const consumers = useGetConsumersWithFullNames();
   const pad = useMemo(() => (num: number) => num < 10 ? `0${num}` : num, []);
-
-  // Modal states for collection details
-  const [isCollectionModalOpen, setIsCollectionModalOpen] = useState(false);
-  const [selectedTableId, setSelectedTableId] = useState<number | undefined>(undefined);
-  const [selectedCollectionId, setSelectedCollectionId] = useState<number | undefined>(undefined);
-
-  const formattedCollectionData = useFormattedCollectionData(selectedTableId, selectedCollectionId);
 
   const rows = useMemo(() => {
     return pointHistoriesPayload?.data
@@ -170,27 +161,29 @@ const ConsumerPointHistoryComponent = () => {
             row.status === PointHistoryStatusEnum.COLLECTIONCREATED ||
             row.status === PointHistoryStatusEnum.COLLECTIONCANCELLED;
           if (!isCollectionStatus || !row.collectionId) return <p></p>;
-          const hasTableId = row.tableId != null;
-          return (
-            <p
-              className={`text-blue-500 underline w-fit ${hasTableId ? "cursor-pointer hover:text-blue-700" : "opacity-50 pointer-events-none"}`}
-              onClick={(e) => {
-                e.stopPropagation();
-                if (hasTableId) {
-                  setSelectedTableId(row.tableId);
-                  setSelectedCollectionId(row.collectionId);
-                  setIsCollectionModalOpen(true);
-                }
-              }}
-            >
-              {row.collectionId}
-            </p>
-          );
-        }
+          return <p>{row.collectionId}</p>;
+        },
       },
       {
         key: "tableId",
         className: "min-w-32 pr-1",
+        node: (row: PointHistory & { formattedDate: string; date: string }) => {
+          if (!row.tableId) return <p></p>;
+          return (
+            <p
+              className="text-blue-500 underline cursor-pointer hover:text-blue-700 w-fit"
+              onClick={(e) => {
+                e.stopPropagation();
+                window.open(
+                  `/order-datas?tab=${OrderDataTabEnum.COLLECTIONS}&search=${row.tableId}&date=${row.date}`,
+                  "_blank"
+                );
+              }}
+            >
+              {row.tableId}
+            </p>
+          );
+        },
       },
       {
         key: "oldAmount",
@@ -223,7 +216,7 @@ const ConsumerPointHistoryComponent = () => {
         },
       },
     ],
-    [t, setSelectedTableId, setSelectedCollectionId, setIsCollectionModalOpen]
+    [t]
   );
 
   const filters = useMemo(
@@ -317,18 +310,7 @@ const ConsumerPointHistoryComponent = () => {
       />
     </div>
 
-    {formattedCollectionData && (
-      <CollectionDetailsModal
-        isOpen={isCollectionModalOpen}
-        onClose={() => {
-          setIsCollectionModalOpen(false);
-          setSelectedTableId(undefined);
-          setSelectedCollectionId(undefined);
-        }}
-        collectionData={formattedCollectionData}
-      />
-    )}
-    </>
+</>
   );
 };
 

--- a/src/components/points/UsersPointHistory.tsx
+++ b/src/components/points/UsersPointHistory.tsx
@@ -1,15 +1,13 @@
 import { format } from "date-fns";
-import { useMemo, useState } from "react";
+import { useMemo } from "react";
 import { useTranslation } from "react-i18next";
 import { useFilterContext } from "../../context/Filter.context";
 import { useGeneralContext } from "../../context/General.context";
-import { PointHistory, pointHistoryStatuses, PointHistoryStatusEnum } from "../../types";
+import { OrderDataTabEnum, PointHistory, pointHistoryStatuses, PointHistoryStatusEnum } from "../../types";
 import { useGetConsumersWithFullNames } from "../../utils/api/consumer";
 import { useGetPointHistories } from "../../utils/api/pointHistory";
 import { useGetUsersMinimal } from "../../utils/api/user";
 import { formatAsLocalDate } from "../../utils/format";
-import { useFormattedCollectionData } from "../../hooks/useFormattedCollectionData";
-import CollectionDetailsModal from "./CollectionDetailsModal";
 import GenericTable from "../panelComponents/Tables/GenericTable";
 import SwitchButton from "../panelComponents/common/SwitchButton";
 import { InputTypes } from "../panelComponents/shared/types";
@@ -30,13 +28,6 @@ const UsersPointHistoryComponent = () => {
   const users = useGetUsersMinimal();
   const consumers = useGetConsumersWithFullNames();
   const pad = useMemo(() => (num: number) => num < 10 ? `0${num}` : num, []);
-
-  // Modal states for collection details
-  const [isCollectionModalOpen, setIsCollectionModalOpen] = useState(false);
-  const [selectedTableId, setSelectedTableId] = useState<number | undefined>(undefined);
-  const [selectedCollectionId, setSelectedCollectionId] = useState<number | undefined>(undefined);
-
-  const formattedCollectionData = useFormattedCollectionData(selectedTableId, selectedCollectionId);
 
   const rows = useMemo(() => {
     return pointHistoriesPayload?.data
@@ -180,27 +171,29 @@ const UsersPointHistoryComponent = () => {
             row.status === PointHistoryStatusEnum.COLLECTIONCREATED ||
             row.status === PointHistoryStatusEnum.COLLECTIONCANCELLED;
           if (!isCollectionStatus || !row.collectionId) return <p></p>;
-          const hasTableId = row.tableId != null;
-          return (
-            <p
-              className={`text-blue-500 underline w-fit ${hasTableId ? "cursor-pointer hover:text-blue-700" : "opacity-50 pointer-events-none"}`}
-              onClick={(e) => {
-                e.stopPropagation();
-                if (hasTableId) {
-                  setSelectedTableId(row.tableId);
-                  setSelectedCollectionId(row.collectionId);
-                  setIsCollectionModalOpen(true);
-                }
-              }}
-            >
-              {row.collectionId}
-            </p>
-          );
-        }
+          return <p>{row.collectionId}</p>;
+        },
       },
       {
         key: "tableId",
         className: "min-w-32 pr-1",
+        node: (row: PointHistory & { formattedDate: string; date: string }) => {
+          if (!row.tableId) return <p></p>;
+          return (
+            <p
+              className="text-blue-500 underline cursor-pointer hover:text-blue-700 w-fit"
+              onClick={(e) => {
+                e.stopPropagation();
+                window.open(
+                  `/order-datas?tab=${OrderDataTabEnum.COLLECTIONS}&search=${row.tableId}&date=${row.date}`,
+                  "_blank"
+                );
+              }}
+            >
+              {row.tableId}
+            </p>
+          );
+        },
       },
       {
         key: "oldAmount",
@@ -233,7 +226,7 @@ const UsersPointHistoryComponent = () => {
         },
       },
     ],
-    [t, setSelectedTableId, setSelectedCollectionId, setIsCollectionModalOpen]
+    [t]
   );
 
   const filters = useMemo(
@@ -327,18 +320,7 @@ const UsersPointHistoryComponent = () => {
         />
       </div>
 
-      {formattedCollectionData && (
-        <CollectionDetailsModal
-          isOpen={isCollectionModalOpen}
-          onClose={() => {
-            setIsCollectionModalOpen(false);
-            setSelectedTableId(undefined);
-            setSelectedCollectionId(undefined);
-          }}
-          collectionData={formattedCollectionData}
-        />
-      )}
-    </>
+</>
   );
 };
 

--- a/src/components/points/UsersPointHistory.tsx
+++ b/src/components/points/UsersPointHistory.tsx
@@ -3,7 +3,7 @@ import { useMemo, useState } from "react";
 import { useTranslation } from "react-i18next";
 import { useFilterContext } from "../../context/Filter.context";
 import { useGeneralContext } from "../../context/General.context";
-import { PointHistory, pointHistoryStatuses, PointHistoryStatusEnum } from "../../types";
+import { OrderDataTabEnum, PointHistory, pointHistoryStatuses, PointHistoryStatusEnum } from "../../types";
 import { useGetConsumersWithFullNames } from "../../utils/api/consumer";
 import { useGetPointHistories } from "../../utils/api/pointHistory";
 import { useGetUsersMinimal } from "../../utils/api/user";
@@ -180,27 +180,29 @@ const UsersPointHistoryComponent = () => {
             row.status === PointHistoryStatusEnum.COLLECTIONCREATED ||
             row.status === PointHistoryStatusEnum.COLLECTIONCANCELLED;
           if (!isCollectionStatus || !row.collectionId) return <p></p>;
-          const hasTableId = row.tableId != null;
-          return (
-            <p
-              className={`text-blue-500 underline w-fit ${hasTableId ? "cursor-pointer hover:text-blue-700" : "opacity-50 pointer-events-none"}`}
-              onClick={(e) => {
-                e.stopPropagation();
-                if (hasTableId) {
-                  setSelectedTableId(row.tableId);
-                  setSelectedCollectionId(row.collectionId);
-                  setIsCollectionModalOpen(true);
-                }
-              }}
-            >
-              {row.collectionId}
-            </p>
-          );
-        }
+          return <p>{row.collectionId}</p>;
+        },
       },
       {
         key: "tableId",
         className: "min-w-32 pr-1",
+        node: (row: PointHistory) => {
+          if (!row.tableId) return <p></p>;
+          return (
+            <p
+              className="text-blue-500 underline cursor-pointer hover:text-blue-700 w-fit"
+              onClick={(e) => {
+                e.stopPropagation();
+                window.open(
+                  `/order-datas?tab=${OrderDataTabEnum.COLLECTIONS}&search=${row.tableId}&resetDateFilter=true`,
+                  "_blank"
+                );
+              }}
+            >
+              {row.tableId}
+            </p>
+          );
+        },
       },
       {
         key: "oldAmount",
@@ -233,7 +235,7 @@ const UsersPointHistoryComponent = () => {
         },
       },
     ],
-    [t, setSelectedTableId, setSelectedCollectionId, setIsCollectionModalOpen]
+    [t]
   );
 
   const filters = useMemo(

--- a/src/components/points/UsersPointHistory.tsx
+++ b/src/components/points/UsersPointHistory.tsx
@@ -186,7 +186,7 @@ const UsersPointHistoryComponent = () => {
       {
         key: "tableId",
         className: "min-w-32 pr-1",
-        node: (row: PointHistory) => {
+        node: (row: PointHistory & { formattedDate: string; date: string }) => {
           if (!row.tableId) return <p></p>;
           return (
             <p
@@ -194,7 +194,7 @@ const UsersPointHistoryComponent = () => {
               onClick={(e) => {
                 e.stopPropagation();
                 window.open(
-                  `/order-datas?tab=${OrderDataTabEnum.COLLECTIONS}&search=${row.tableId}&resetDateFilter=true`,
+                  `/order-datas?tab=${OrderDataTabEnum.COLLECTIONS}&search=${row.tableId}&date=${row.date}`,
                   "_blank"
                 );
               }}

--- a/src/pages/OrderDatas.tsx
+++ b/src/pages/OrderDatas.tsx
@@ -26,7 +26,10 @@ import SingleProductSalesReport from "../components/orderDatas/SingleProductSale
 import TrendyolOrders from "../components/orderDatas/TrendyolOrders";
 import UpperCategoryBasedSalesReport from "../components/orderDatas/UpperCategoryBasedSalesReport";
 import UnifiedTabPanel from "../components/panelComponents/TabPanel/UnifiedTabPanel";
+import { useEffect, useRef } from "react";
+import { useSearchParams } from "react-router-dom";
 import { useGeneralContext } from "../context/General.context";
+import { useOrderContext } from "../context/Order.context";
 import { useUserContext } from "../context/User.context";
 import { OrderDataTabEnum } from "../types";
 import { useGetAllCategories } from "../utils/api/menu/category";
@@ -140,6 +143,23 @@ const OrderDatas = () => {
     orderDataActiveTab,
     setOrderDataActiveTab,
   } = useGeneralContext();
+  const { filterPanelFormElements, setFilterPanelFormElements } = useOrderContext();
+  const [searchParams] = useSearchParams();
+  const skipSearchClear = useRef(false);
+
+  useEffect(() => {
+    const tab = searchParams.get("tab");
+    const search = searchParams.get("search");
+    const date = searchParams.get("date");
+    if (tab !== null) {
+      if (search !== null) skipSearchClear.current = true;
+      setOrderDataActiveTab(Number(tab));
+    }
+    if (search !== null) setSearchQuery(search);
+    if (date !== null) {
+      setFilterPanelFormElements({ ...filterPanelFormElements, after: date, before: "" });
+    }
+  }, []);
   const categories = useGetAllCategories();
   const enumTabCount = Object.keys(OrderDataTabEnum).length / 2;
   const currentPageId = "order_datas";
@@ -184,7 +204,11 @@ const OrderDatas = () => {
         setActiveTab={setOrderDataActiveTab}
         additionalOpenAction={() => {
           setCurrentPage(1);
-          setSearchQuery("");
+          if (skipSearchClear.current) {
+            skipSearchClear.current = false;
+          } else {
+            setSearchQuery("");
+          }
         }}
         allowOrientationToggle={true}
       />

--- a/src/pages/OrderDatas.tsx
+++ b/src/pages/OrderDatas.tsx
@@ -25,7 +25,6 @@ import PersonalOrderDatas from "../components/orderDatas/PersonalOrderDatas";
 import SingleProductSalesReport from "../components/orderDatas/SingleProductSalesReport";
 import UpperCategoryBasedSalesReport from "../components/orderDatas/UpperCategoryBasedSalesReport";
 import UnifiedTabPanel from "../components/panelComponents/TabPanel/UnifiedTabPanel";
-import { format } from "date-fns";
 import { useEffect, useRef } from "react";
 import { useSearchParams } from "react-router-dom";
 import { useGeneralContext } from "../context/General.context";
@@ -143,18 +142,14 @@ const OrderDatas = () => {
   useEffect(() => {
     const tab = searchParams.get("tab");
     const search = searchParams.get("search");
-    const resetDateFilter = searchParams.get("resetDateFilter");
+    const date = searchParams.get("date");
     if (tab !== null) {
       if (search !== null) skipSearchClear.current = true;
       setOrderDataActiveTab(Number(tab));
     }
     if (search !== null) setSearchQuery(search);
-    if (resetDateFilter === "true") {
-      setFilterPanelFormElements({
-        ...filterPanelFormElements,
-        after: `${format(new Date(), "yyyy")}-01-01`,
-        before: "",
-      });
+    if (date !== null) {
+      setFilterPanelFormElements({ ...filterPanelFormElements, after: date, before: "" });
     }
   }, []);
   const categories = useGetAllCategories();

--- a/src/pages/OrderDatas.tsx
+++ b/src/pages/OrderDatas.tsx
@@ -25,7 +25,11 @@ import PersonalOrderDatas from "../components/orderDatas/PersonalOrderDatas";
 import SingleProductSalesReport from "../components/orderDatas/SingleProductSalesReport";
 import UpperCategoryBasedSalesReport from "../components/orderDatas/UpperCategoryBasedSalesReport";
 import UnifiedTabPanel from "../components/panelComponents/TabPanel/UnifiedTabPanel";
+import { format } from "date-fns";
+import { useEffect, useRef } from "react";
+import { useSearchParams } from "react-router-dom";
 import { useGeneralContext } from "../context/General.context";
+import { useOrderContext } from "../context/Order.context";
 import { useUserContext } from "../context/User.context";
 import { OrderDataTabEnum } from "../types";
 import { useGetAllCategories } from "../utils/api/menu/category";
@@ -132,6 +136,27 @@ const OrderDatas = () => {
     orderDataActiveTab,
     setOrderDataActiveTab,
   } = useGeneralContext();
+  const { filterPanelFormElements, setFilterPanelFormElements } = useOrderContext();
+  const [searchParams] = useSearchParams();
+  const skipSearchClear = useRef(false);
+
+  useEffect(() => {
+    const tab = searchParams.get("tab");
+    const search = searchParams.get("search");
+    const resetDateFilter = searchParams.get("resetDateFilter");
+    if (tab !== null) {
+      if (search !== null) skipSearchClear.current = true;
+      setOrderDataActiveTab(Number(tab));
+    }
+    if (search !== null) setSearchQuery(search);
+    if (resetDateFilter === "true") {
+      setFilterPanelFormElements({
+        ...filterPanelFormElements,
+        after: `${format(new Date(), "yyyy")}-01-01`,
+        before: "",
+      });
+    }
+  }, []);
   const categories = useGetAllCategories();
   const enumTabCount = Object.keys(OrderDataTabEnum).length / 2;
   const currentPageId = "order_datas";
@@ -176,7 +201,11 @@ const OrderDatas = () => {
         setActiveTab={setOrderDataActiveTab}
         additionalOpenAction={() => {
           setCurrentPage(1);
-          setSearchQuery("");
+          if (skipSearchClear.current) {
+            skipSearchClear.current = false;
+          } else {
+            setSearchQuery("");
+          }
         }}
         allowOrientationToggle={true}
       />


### PR DESCRIPTION
- Yeni sekmede /order-datas adresine gidiliyor,
- Otomatik olarak "Tahsilatlar" sekmesine geçiliyor,
- Tıklanan masanın ID'si arama kutusuna otomatik yazılıyor,
- Tarih filtresi, tıklanan kaydın tarihine göre otomatik ayarlanıyor,
- Puan geçmişi sayfalarındaki "Tahsilat ID" kolonundaki değerler artık tıklanamaz (önceden tıklanınca açılan detay penceresi kaldırıldı, yönlendirme ise tableId üzerinden yapılıyor)
