### PR TITLE
Ürün fiyat grafiği sıralama ve x-axis label sorunu giderildi

### DIFF
--- a/src/components/analytics/accounting/PriceChart.tsx
+++ b/src/components/analytics/accounting/PriceChart.tsx
@@ -138,10 +138,11 @@ const PriceChart = ({
             axisBottom={{
               tickSize: 5,
               tickPadding: 5,
-              tickRotation: 0,
+              tickRotation: chartConfig?.tickValues ? -35 : 0,
               legend: "",
               legendOffset: 45,
               legendPosition: "middle",
+              tickValues: chartConfig?.tickValues,
             }}
             axisLeft={{
               tickSize: 5,

--- a/src/components/product/ProductPrice.tsx
+++ b/src/components/product/ProductPrice.tsx
@@ -24,7 +24,7 @@ const ProductPrice = () => {
     const step = Math.max(1, Math.ceil(dates.length / 20));
     const tickValues = dates
       .filter((_, i) => i % step === 0 || i === dates.length - 1)
-      .map((d) => formatAsLocalDate(d ?? ""));
+      .map((d) => d ? formatAsLocalDate(d) : "");
 
     return {
       height: 240,

--- a/src/components/product/ProductPrice.tsx
+++ b/src/components/product/ProductPrice.tsx
@@ -14,15 +14,22 @@ const ProductPrice = () => {
   const invoices = useGetAccountProductExpenses(selectedProduct?._id ?? "");
 
   const chartConfig = useMemo(() => {
-    const prices =
-      invoices?.map((invoice) =>
-        parseFloat((invoice.totalExpense / invoice.quantity).toFixed(4))
-      ) ?? [];
-    const dates = invoices?.map((invoice) => invoice.date) ?? [];
+    const sorted = [...(invoices ?? [])].sort((a, b) =>
+      (a.date ?? "").localeCompare(b.date ?? "")
+    );
+    const prices = sorted.map((invoice) =>
+      parseFloat((invoice.totalExpense / invoice.quantity).toFixed(4))
+    );
+    const dates = sorted.map((invoice) => invoice.date);
+    const step = Math.max(1, Math.ceil(dates.length / 20));
+    const tickValues = dates
+      .filter((_, i) => i % step === 0 || i === dates.length - 1)
+      .map((d) => formatAsLocalDate(d ?? ""));
 
     return {
       height: 240,
-      type: invoices?.length > 1 ? "line" : "bar",
+      type: sorted.length > 1 ? "line" : "bar",
+      tickValues,
       series: [
         {
           name: "Price",


### PR DESCRIPTION
## Yapılan Değişiklikler

- Gelen expense verileri tarihe göre sıralandı (geri atlayan çizgiler ve üçgen şekiller giderildi)
- Tüm alım kayıtları grafikte gösterilirken x-axis altında sadece belirli tarihler yazılacak şekilde düzenlendi; böylece tarihler üst üste binmeden okunabilir hale geldi
- PriceChart bileşenine hangi tarihlerin x-axis'te yazılacağını dışarıdan belirleyebilen tickValues prop desteği eklendi.