### PR TITLE
fix(imageUpload): klasör seçimi dropdown'ı tablonun arkasında kalıyordu

### DIFF
--- a/src/components/imageUpload/ImageUpload.tsx
+++ b/src/components/imageUpload/ImageUpload.tsx
@@ -142,6 +142,8 @@ const ImageUpload = ({ isFolderSelect = true, itemId }: Props) => {
                   );
                 }}
                 placeholder={t("Select a folder")}
+                menuPortalTarget={document.body}
+                menuZIndex={9999}
               />
             </div>
           )}

--- a/src/components/panelComponents/FormElements/SelectInput.tsx
+++ b/src/components/panelComponents/FormElements/SelectInput.tsx
@@ -55,6 +55,8 @@ interface SelectInputProps {
   isSortDisabled?: boolean;
   customControlBackgroundColor?: string;
   isExpandedMultiValueLabel?: boolean;
+  menuPortalTarget?: HTMLElement | null;
+  menuZIndex?: number;
 }
 
 const normalizeText = (text: string) => {
@@ -110,6 +112,8 @@ const SelectInput = ({
   suggestedOption,
   customControlBackgroundColor,
   isExpandedMultiValueLabel = false,
+  menuPortalTarget,
+  menuZIndex,
 }: SelectInputProps) => {
   const [searchInput, setSearchInput] = useState("");
   const [isSearchable, setIsSearchable] = useState(false);
@@ -137,6 +141,9 @@ const SelectInput = ({
     menu: (base: any) => ({
       ...base,
       overflowY: "auto",
+    }),
+    ...(menuZIndex !== undefined && {
+      menuPortal: (base: any) => ({ ...base, zIndex: menuZIndex }),
     }),
     option: (base: any, state: any) => ({
       ...base,
@@ -332,6 +339,7 @@ const SelectInput = ({
               menuShouldScrollIntoView={true}
               menuPlacement={isMobile ? "bottom" : "auto"}
               menuPosition={isMobile ? "absolute" : "fixed"}
+              menuPortalTarget={menuPortalTarget}
             />
           ) : (
             <Select
@@ -358,6 +366,7 @@ const SelectInput = ({
               menuShouldScrollIntoView={true}
               menuPlacement={isMobile ? "bottom" : "auto"}
               menuPosition={isMobile ? "absolute" : "fixed"}
+              menuPortalTarget={menuPortalTarget}
               isClearable={false}
               backspaceRemovesValue={true}
             />


### PR DESCRIPTION
menuPortalTarget ile body'e portal edilen menünün z-index'i react-select'te varsayılan olarak 1 geldiğinden tablo başlığının arkasında kalıyordu. SelectInput'a opsiyonel menuZIndex prop'u eklenerek yalnızca ImageUpload bileşeninde 9999 olarak ayarlandı.