### PR TITLE
/count-list sayfası geliştirmeler

### DIFF
--- a/src/pages/Count.tsx
+++ b/src/pages/Count.tsx
@@ -35,6 +35,7 @@ import { useGetMenuItems } from "../utils/api/menu/menu-item";
 import { useGetDisabledConditions } from "../utils/api/panelControl/disabledCondition";
 import { getItem } from "../utils/getItem";
 import { isActionDisabled } from "../utils/permissions";
+import { getCountStockBgColor } from "../utils/color";
 
 const Count = () => {
   const { t, i18n } = useTranslation();
@@ -63,12 +64,6 @@ const Count = () => {
   const countArchiveOpenCountDisabledCondition = useMemo(() => {
     return getItem(DisabledConditionEnum.COUNTARCHIVE_COUNT, disabledConditions);
   }, [disabledConditions]);
-
-  function getBgColor(row: { stockQuantity: number; countQuantity: number }) {
-    if (Number(row.stockQuantity) === Number(row.countQuantity)) return "bg-blue-100";
-    if (Number(row.stockQuantity) > Number(row.countQuantity)) return "bg-red-100";
-    return "bg-green-100";
-  }
 
   const numericLocation = useMemo(
     () => (location ? Number(location) : undefined),
@@ -205,6 +200,7 @@ const Count = () => {
     numericLocation,
     products,
     items,
+    stocks,
     currentCount?.products,
     i18n.language,
   ]);
@@ -518,7 +514,7 @@ const Count = () => {
           addButton={addButton}
           filters={filters}
           actions={isEnableEdit ? actions : []}
-          rowClassNameFunction={showStockAndColors ? getBgColor : undefined}
+          rowClassNameFunction={showStockAndColors ? getCountStockBgColor : undefined}
         />
         <div className="flex justify-end flex-row gap-2 mt-4">
           <GenericButton variant="danger" size="sm" onClick={cancelCount}>

--- a/src/pages/Count.tsx
+++ b/src/pages/Count.tsx
@@ -19,7 +19,7 @@ import {
 import { useGeneralContext } from "../context/General.context";
 import { useUserContext } from "../context/User.context";
 import { Routes } from "../navigation/constants";
-import { CountListPageTabEnum } from "../types";
+import { ActionEnum, CountListPageTabEnum, DisabledConditionEnum } from "../types";
 import {
   useAccountCountMutations,
   useGetAccountCounts,
@@ -32,6 +32,9 @@ import {
 import { useGetAccountProducts } from "../utils/api/account/product";
 import { useGetAccountStocks } from "../utils/api/account/stock";
 import { useGetMenuItems } from "../utils/api/menu/menu-item";
+import { useGetDisabledConditions } from "../utils/api/panelControl/disabledCondition";
+import { getItem } from "../utils/getItem";
+import { isActionDisabled } from "../utils/permissions";
 
 const Count = () => {
   const { t, i18n } = useTranslation();
@@ -55,19 +58,31 @@ const Count = () => {
     product: [],
   });
 
+  const disabledConditions = useGetDisabledConditions();
+
+  const countArchiveOpenCountDisabledCondition = useMemo(() => {
+    return getItem(DisabledConditionEnum.COUNTARCHIVE_COUNT, disabledConditions);
+  }, [disabledConditions]);
+
+  function getBgColor(row: { stockQuantity: number; countQuantity: number }) {
+    if (Number(row.stockQuantity) === Number(row.countQuantity)) return "bg-blue-100";
+    if (Number(row.stockQuantity) > Number(row.countQuantity)) return "bg-red-100";
+    return "bg-green-100";
+  }
+
   const numericLocation = useMemo(
     () => (location ? Number(location) : undefined),
     [location]
   );
 
   const currentCount = useMemo(() => {
-    return counts?.find(
+    const openCounts = counts?.filter(
       (item) =>
         item.isCompleted === false &&
         item.location === numericLocation &&
-        item.user === user?._id &&
         item.countList === countListId
     );
+    return openCounts?.find((item) => item.user === user?._id) ?? openCounts?.[0];
   }, [counts, numericLocation, user?._id, countListId]);
 
   const currentCountList = useMemo(
@@ -117,15 +132,26 @@ const Count = () => {
     []
   );
 
+  const showStockAndColors = useMemo(
+    () => !isActionDisabled(countArchiveOpenCountDisabledCondition, ActionEnum.ADVANCED_VIEW, user),
+    [countArchiveOpenCountDisabledCondition, user]
+  );
+
   const columns = useMemo(() => {
     const base = [
       { key: t("Product"), isSortable: true },
       { key: t("Shelf"), isSortable: true },
+      ...(showStockAndColors
+        ? [
+            { key: t("Stock Quantity"), isSortable: true },
+            { key: t("Difference"), isSortable: false },
+          ]
+        : []),
       { key: t("Quantity"), isSortable: true, className: "mx-auto" },
     ];
     if (isEnableEdit) base.push({ key: t("Actions"), isSortable: false });
     return base;
-  }, [t, isEnableEdit]);
+  }, [t, isEnableEdit, showStockAndColors]);
 
   const rows = useMemo(() => {
     const listProducts = currentCountList?.products ?? [];
@@ -152,7 +178,7 @@ const Count = () => {
               product: foundProduct?.name || "",
               countQuantity: currentCount?.products?.find(
                 (cp: any) => cp.product === countListProduct.product
-              )?.countQuantity,
+              )?.countQuantity ?? 0,
               productDeleteRequest: currentCount?.products?.find(
                 (cp: any) => cp.product === countListProduct.product
               )?.productDeleteRequest,
@@ -162,6 +188,12 @@ const Count = () => {
                 )?.shelf || "",
               sku: foundMenuItem?.sku || "",
               barcode: foundMenuItem?.barcode || "",
+              stockQuantity:
+                stocks?.find(
+                  (s) =>
+                    s?.product === countListProduct.product &&
+                    s?.location === numericLocation
+                )?.quantity || 0,
             };
           }
           return { product: "", countQuantity: 0 };
@@ -176,6 +208,24 @@ const Count = () => {
     currentCount?.products,
     i18n.language,
   ]);
+
+  const sortedRows = useMemo(() => {
+    if (!showStockAndColors) {
+      return [...rows].sort((a, b) => a.product.localeCompare(b.product));
+    }
+    const colorRank = (row: { stockQuantity?: number; countQuantity: number }) => {
+      const s = Number(row.stockQuantity ?? 0);
+      const c = Number(row.countQuantity);
+      if (s > c) return 0; // red
+      if (s < c) return 1; // green
+      return 2;            // blue
+    };
+    return [...rows].sort((a, b) => {
+      const rankDiff = colorRank(a) - colorRank(b);
+      if (rankDiff !== 0) return rankDiff;
+      return a.product.localeCompare(b.product);
+    });
+  }, [rows, showStockAndColors]);
 
   const addButton = useMemo(
     () => ({
@@ -312,6 +362,18 @@ const Count = () => {
         },
       },
       { key: "shelfInfo" },
+      ...(showStockAndColors
+        ? [
+            { key: "stockQuantity" },
+            {
+              key: "difference",
+              node: (row: any) => {
+                const diff = Number(row.countQuantity) - Number(row.stockQuantity);
+                return <span>{diff > 0 ? `+${diff}` : diff}</span>;
+              },
+            },
+          ]
+        : []),
       {
         key: "countQuantity",
         node: (row: any) => {
@@ -356,14 +418,14 @@ const Count = () => {
                 isTopFlexRow={false}
                 minNumber={0}
                 isMinNumber={true}
-                className="w-20 h-10 text-center"
+                className="w-20 h-10 text-center bg-transparent"
               />
             </div>
           );
         },
       },
     ],
-    [products, currentCount, stocks, numericLocation, updateCountQuantity]
+    [products, currentCount, stocks, numericLocation, updateCountQuantity, showStockAndColors]
   );
 
   const filters = useMemo(
@@ -449,13 +511,14 @@ const Count = () => {
         <GenericTable
           rowKeys={rowKeys}
           columns={columns}
-          rows={rows}
+          rows={sortedRows}
           title={t("Count")}
           searchRowKeys={[...rowKeys, { key: "sku" }, { key: "barcode" }]}
           isActionsActive={isEnableEdit}
           addButton={addButton}
           filters={filters}
           actions={isEnableEdit ? actions : []}
+          rowClassNameFunction={showStockAndColors ? getBgColor : undefined}
         />
         <div className="flex justify-end flex-row gap-2 mt-4">
           <GenericButton variant="danger" size="sm" onClick={cancelCount}>

--- a/src/pages/SingleCountArchive.tsx
+++ b/src/pages/SingleCountArchive.tsx
@@ -1,5 +1,5 @@
 import { toZonedTime } from "date-fns-tz";
-import { useCallback, useMemo, useState } from "react";
+import { useMemo, useState } from "react";
 import { useTranslation } from "react-i18next";
 import { HiOutlineTrash } from "react-icons/hi2";
 import { IoCheckmark, IoCloseOutline } from "react-icons/io5";
@@ -34,6 +34,7 @@ import { useGetMenuItems } from "../utils/api/menu/menu-item";
 import { useGetDisabledConditions } from "../utils/api/panelControl/disabledCondition";
 import { useGetUsersMinimal } from "../utils/api/user";
 import { getItem } from "../utils/getItem";
+import { isActionDisabled } from "../utils/permissions";
 
 const SingleCountArchive = () => {
   const { t } = useTranslation();
@@ -61,28 +62,12 @@ const SingleCountArchive = () => {
 
   const disabledConditions = useGetDisabledConditions();
 
-  const countArchiveInnerpageDisabledCondition = useMemo(() => {
+  const countArchiveCompletedCountDisabledCondition = useMemo(() => {
     return getItem(
-      DisabledConditionEnum.COUNTARCHIVE_INNERPAGE,
+      DisabledConditionEnum.COUNTARCHIVE_SINGLECOUNTARCHIVE,
       disabledConditions
     );
   }, [disabledConditions]);
-
-  const isActionDisabled = useCallback(
-    (actionType: ActionEnum) => {
-      if (!user?.role?._id) {
-        return true;
-      }
-      const action = countArchiveInnerpageDisabledCondition?.actions?.find(
-        (ac) => ac.action === actionType
-      );
-      if (!action) {
-        return false;
-      }
-      return !action.permissionsRoles?.includes(user.role._id);
-    },
-    [countArchiveInnerpageDisabledCondition, user]
-  );
 
   const currentCount = useMemo(() => {
     return count;
@@ -162,19 +147,22 @@ const SingleCountArchive = () => {
         })
         .filter((row): row is NonNullable<typeof row> => row !== null)
         .sort((a, b) => {
-          const rank = (row: typeof a) =>
-            row.stockQuantity > row.countQuantity
-              ? 0
-              : row.stockQuantity < row.countQuantity
-              ? 1
-              : 2;
-          return rank(a) - rank(b);
+          const colorRank = (row: { stockQuantity: number; countQuantity: number }) => {
+            const s = Number(row.stockQuantity);
+            const c = Number(row.countQuantity);
+            if (s > c) return 0; // red
+            if (s < c) return 1; // green
+            return 2;            // blue
+          };
+          const rankDiff = colorRank(a) - colorRank(b);
+          if (rankDiff !== 0) return rankDiff;
+          return a.product.localeCompare(b.product);
         }) ?? []
     );
   }, [currentCount, products, users, pad]);
 
   const { columns, rowKeys } = useMemo(() => {
-    const showInnerDatas = !isActionDisabled(ActionEnum.SHOW_INNER_DATAS);
+    const showInnerDatas = !isActionDisabled(countArchiveCompletedCountDisabledCondition, ActionEnum.SHOW_INNER_DATAS, user);
 
     const cols = [
       { key: t("Date"), isSortable: true },
@@ -183,6 +171,7 @@ const SingleCountArchive = () => {
       { key: t("SKU"), isSortable: false },
       { key: t("Stock Quantity"), isSortable: true },
       { key: t("Count Quantity"), isSortable: true },
+      { key: t("Difference"), isSortable: true },
       { key: t("Delete Request"), isSortable: true },
       ...(showInnerDatas
         ? [
@@ -199,6 +188,13 @@ const SingleCountArchive = () => {
       { key: "sku" },
       { key: "stockQuantity" },
       { key: "countQuantity" },
+      {
+        key: "difference",
+        node: (row: any) => {
+          const diff = Number(row.countQuantity) - Number(row.stockQuantity);
+          return <span>{diff > 0 ? `+${diff}` : diff}</span>;
+        },
+      },
       { key: "productDeleteRequest" },
       ...(showInnerDatas
         ? [
@@ -217,12 +213,12 @@ const SingleCountArchive = () => {
     ];
 
     return { columns: cols, rowKeys: keys };
-  }, [t, isActionDisabled]);
+  }, [t, countArchiveCompletedCountDisabledCondition, user]);
 
   const displayRows = useMemo(() => {
-    if (isActionDisabled(ActionEnum.SHOW_INNER_DATAS)) return [];
+    if (isActionDisabled(countArchiveCompletedCountDisabledCondition, ActionEnum.SHOW_INNER_DATAS, user)) return [];
     return rows;
-  }, [rows, isActionDisabled]);
+  }, [rows, countArchiveCompletedCountDisabledCondition, user]);
 
   function getBgColor(row: {
     stockQuantity: number;
@@ -310,7 +306,7 @@ const SingleCountArchive = () => {
         isModalOpen: isCloseAllConfirmationDialogOpen,
         setIsModal: setIsCloseAllConfirmationDialogOpen,
         isPath: false,
-        isDisabled: isActionDisabled(ActionEnum.DELETE),
+        isDisabled: isActionDisabled(countArchiveCompletedCountDisabledCondition, ActionEnum.DELETE, user),
       },
       {
         name: t("Equalize"),
@@ -339,7 +335,7 @@ const SingleCountArchive = () => {
         className: "text-red-500 cursor-pointer text-2xl",
         isModal: false,
         isPath: false,
-        isDisabled: isActionDisabled(ActionEnum.EQUAL),
+        isDisabled: isActionDisabled(countArchiveCompletedCountDisabledCondition, ActionEnum.EQUAL, user),
       },
     ],
     [
@@ -349,7 +345,8 @@ const SingleCountArchive = () => {
       currentCountList,
       updateAccountCountList,
       updateStockForStockCount,
-      isActionDisabled,
+      countArchiveCompletedCountDisabledCondition,
+      user,
     ]
   );
 
@@ -357,7 +354,7 @@ const SingleCountArchive = () => {
     () => [
       {
         isUpperSide: false,
-        isDisabled: isActionDisabled(ActionEnum.EQUAL_STOCKS),
+        isDisabled: isActionDisabled(countArchiveCompletedCountDisabledCondition, ActionEnum.EQUAL_STOCKS, user),
         node: (
           <ButtonFilter
             buttonName={t("Stock Equalize")}
@@ -380,14 +377,14 @@ const SingleCountArchive = () => {
         ),
       },
     ],
-    [t, isActionDisabled, currentCount, archiveId, updateStockForStockCountBulk]
+    [t, countArchiveCompletedCountDisabledCondition, user, currentCount, archiveId, updateStockForStockCountBulk]
   );
 
   const rowClassNameFunction = useMemo(() => {
-    return !isActionDisabled(ActionEnum.SHOW_INNER_DATAS)
+    return !isActionDisabled(countArchiveCompletedCountDisabledCondition, ActionEnum.SHOW_INNER_DATAS, user)
       ? getBgColor
       : undefined;
-  }, [isActionDisabled]);
+  }, [countArchiveCompletedCountDisabledCondition, user]);
 
   return (
     <>

--- a/src/pages/SingleCountArchive.tsx
+++ b/src/pages/SingleCountArchive.tsx
@@ -35,6 +35,7 @@ import { useGetDisabledConditions } from "../utils/api/panelControl/disabledCond
 import { useGetUsersMinimal } from "../utils/api/user";
 import { getItem } from "../utils/getItem";
 import { isActionDisabled } from "../utils/permissions";
+import { getCountStockBgColor } from "../utils/color";
 
 const SingleCountArchive = () => {
   const { t } = useTranslation();
@@ -159,7 +160,7 @@ const SingleCountArchive = () => {
           return a.product.localeCompare(b.product);
         }) ?? []
     );
-  }, [currentCount, products, users, pad]);
+  }, [currentCount, products, items, users, pad]);
 
   const { columns, rowKeys } = useMemo(() => {
     const showInnerDatas = !isActionDisabled(countArchiveCompletedCountDisabledCondition, ActionEnum.SHOW_INNER_DATAS, user);
@@ -219,21 +220,6 @@ const SingleCountArchive = () => {
     if (isActionDisabled(countArchiveCompletedCountDisabledCondition, ActionEnum.SHOW_INNER_DATAS, user)) return [];
     return rows;
   }, [rows, countArchiveCompletedCountDisabledCondition, user]);
-
-  function getBgColor(row: {
-    stockQuantity: number;
-    countQuantity: number;
-    product: string;
-  }) {
-    if (Number(row.stockQuantity) === Number(row.countQuantity)) {
-      return "bg-blue-100";
-    } else if (Number(row.stockQuantity) > Number(row.countQuantity)) {
-      return "bg-red-100";
-    } else if (Number(row.stockQuantity) < Number(row.countQuantity)) {
-      return "bg-green-100";
-    }
-    return "bg-green-500";
-  }
 
   const filters = useMemo(
     () => [
@@ -382,7 +368,7 @@ const SingleCountArchive = () => {
 
   const rowClassNameFunction = useMemo(() => {
     return !isActionDisabled(countArchiveCompletedCountDisabledCondition, ActionEnum.SHOW_INNER_DATAS, user)
-      ? getBgColor
+      ? getCountStockBgColor
       : undefined;
   }, [countArchiveCompletedCountDisabledCondition, user]);
 

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -687,7 +687,9 @@ export enum DisabledConditionEnum {
   POINTS_USERSPOINT = "points_userspoint",
   POINTS_CONSUMERSPOINT = "points_consumerspoint",
   STOCK_SANDWICHSTOCK = "sandwichstock",
-  ORDERS_ORDERS = "orders_orders"
+  ORDERS_ORDERS = "orders_orders",
+  COUNTARCHIVE_SINGLECOUNTARCHIVE = "countarchive_singlecountarchive",
+  COUNTARCHIVE_COUNT = "countarchive_count"
 }
 
 export enum ActionEnum {
@@ -749,7 +751,8 @@ export enum ActionEnum {
   PUBLISH = "publish",
   ADD_TO_RETAILER = "add_to_retailer",
   PROCESS = "process",
-  AUTO_PRINT = "auto_print"
+  AUTO_PRINT = "auto_print",
+  ADVANCED_VIEW = "advanced_view"
 }
 
 export type Membership = {

--- a/src/utils/color.ts
+++ b/src/utils/color.ts
@@ -2,3 +2,12 @@ import { scaleOrdinal } from "d3-scale";
 import { schemeCategory10 } from "d3-scale-chromatic";
 
 export const colors = scaleOrdinal(schemeCategory10).range();
+
+export function getCountStockBgColor(row: {
+  stockQuantity: number;
+  countQuantity: number;
+}): string {
+  if (Number(row.stockQuantity) === Number(row.countQuantity)) return "bg-blue-100";
+  if (Number(row.stockQuantity) > Number(row.countQuantity)) return "bg-red-100";
+  return "bg-green-100";
+}


### PR DESCRIPTION
- Sayım açık iken, manager ve izni olan diğer rollerdeki kullanıcılar; ürünlerin stok bilgilerini, mevcut sayılan miktar ile olan farkı görebiliyor
- Ürün satırları stok-miktar bilgisine göre renklendirildi
- Websocket yayını ile sayım yapan kullanıcı ile manager açık sayım ekranında senkron şekilde değişiklik yapabiliyor
- Tekrar eden renk mantığı color.ts'e taşındı