### PR TITLE
Sidebarda resetleme ve orderin altında mutfakların görünmesi işlemleri

### DIFF
--- a/src/components/common/Sidebar.tsx
+++ b/src/components/common/Sidebar.tsx
@@ -116,6 +116,7 @@ export const Sidebar = () => {
               key={tab.label}
               onClick={() => {
                 resetGeneralContext();
+                setSearchValue("");
                 navigate(`${item.path}?tab=${tabSlug}`);
                 window.scrollTo(0, 0);
                 setIsSidebarOpen(false);

--- a/src/components/header/PageSelector.tsx
+++ b/src/components/header/PageSelector.tsx
@@ -57,6 +57,7 @@ export function PageSelector() {
               key={tab.label}
               onClick={() => {
                 resetGeneralContext();
+                setSearchValue("");
                 navigate(`${item.path}?tab=${tabSlug}`);
                 window.scrollTo(0, 0);
                 setIsMenuOpen(false);

--- a/src/hooks/useSidebarNavigation.ts
+++ b/src/hooks/useSidebarNavigation.ts
@@ -7,7 +7,9 @@ import { useLocation, useNavigate } from "react-router-dom";
 
 import { useGeneralContext } from "../context/General.context";
 import { useUserContext } from "../context/User.context";
+import { useDataContext } from "../context/Data.context";
 import { useFilteredRoutes } from "./useFilteredRoutes";
+import { Routes } from "../navigation/constants";
 import { Role } from "../types";
 import { useGetBreaksByDate } from "../utils/api/break";
 import { useGetGameplayTimesByDate } from "../utils/api/gameplaytime";
@@ -48,9 +50,28 @@ export function useSidebarNavigation(onClose: () => void) {
 
   const { setUser } = useUserContext();
   const { resetGeneralContext, setIsLogoutModalOpen } = useGeneralContext();
+  const { kitchens } = useDataContext();
 
   const user = useGetUser();
-  const routes = useFilteredRoutes() as SidebarRouteItem[];
+  const rawRoutes = useFilteredRoutes() as SidebarRouteItem[];
+
+  const routes = useMemo(() => {
+    if (!kitchens?.length) return rawRoutes;
+    const kitchenTabs: Tab[] = kitchens.map((kitchen, index) => ({
+      number: index,
+      label: kitchen.name,
+      content: null,
+      isDisabled: false,
+    }));
+    return rawRoutes.map((route) =>
+      route.path === Routes.Orders
+        ? {
+            ...route,
+            tabs: kitchenTabs,
+          } : route
+
+    );
+  }, [rawRoutes, kitchens]);
   const pages = useGetPanelControlPages();
 
   const todayDate = format(new Date(), "yyyy-MM-dd");
@@ -147,6 +168,7 @@ export function useSidebarNavigation(onClose: () => void) {
     if (!item.path) return;
 
     resetGeneralContext();
+    setSearchValue("");
 
     const allowedTabs = getAllowedTabs(item);
 


### PR DESCRIPTION
- Searchbara bir değer yazılıp açılan dropdown menüden bir sayfaya gidildiğinde, searchbardaki yazılı kalan metnin başka sayfaya gidildiğinde resetlenmesi
- "Siparişler" (/orders) sayfasındaki mutfak tablarının collapsible olarak gösterilmesi