### PR TITLE
tamamlanmamış bir sayımın sayfası açıldığında miktar değerlerinin sıfır gelmemesi

### DIFF
--- a/src/utils/api/account/count.ts
+++ b/src/utils/api/account/count.ts
@@ -116,7 +116,7 @@ export function useUpdateStockForStockCountBulkMutation() {
   });
 }
 export function useGetAccountCounts() {
-  return useGetList<AccountCount>(baseUrl);
+  return useGetList<AccountCount>(baseUrl, [baseUrl], true);
 }
 export function useGetQueryCounts(
   page: number,


### PR DESCRIPTION
Abi selamlar, ben önceki pr'da miktar kolonundaki değerlerin sıfır gelmemesi için de geliştirme yapmıştım ama useGetList'in stale time'ı 1 saat olduğu için tamamlanmamış sayıma girince miktar kolonunda değerler sıfır geliyordu, sayfaya refresh atınca miktar kolonu doluyordu da yaparken sürekli o sayfaya gir çık yaptığım için fark etmemişim, sayım açıkken gelen sayfada veri çeken fonksiyonun stale time'ını sıfır yaptım, giriş yaptığımızda fetch edecek, lokalde bi tık ağır çalışıyor ama canlıda daha hızlı çalışır diye düşünüyorum