### PR TITLE
(BE'si de var)Lokasyonlara order eklenmesi(testi sürüyor, bitince bu parantezi sileceğim)

### DIFF
--- a/src/components/accounting/GameStock.tsx
+++ b/src/components/accounting/GameStock.tsx
@@ -181,11 +181,27 @@ const GameStock = () => {
       return acc;
     }, {});
 
-    return Object.values(processedRows || {}).sort(
-      (a, b) =>
-        (b as { totalQuantity: number }).totalQuantity -
-        (a as { totalQuantity: number }).totalQuantity
-    );
+    return Object.values(processedRows || {})
+      .map((row: any) => ({
+        ...row,
+        collapsible: {
+          ...row.collapsible,
+          collapsibleRows: [...row.collapsible.collapsibleRows].sort((a, b) => {
+            const orderA =
+              locations.find((l) => l._id === a.stockLocation)?.order ??
+              Infinity;
+            const orderB =
+              locations.find((l) => l._id === b.stockLocation)?.order ??
+              Infinity;
+            return orderA - orderB;
+          }),
+        },
+      }))
+      .sort(
+        (a, b) =>
+          (b as { totalQuantity: number }).totalQuantity -
+          (a as { totalQuantity: number }).totalQuantity
+      );
   }, [filteredStocks, products, items, locations, t, isGameStockEnableEdit]);
 
   const generalTotalExpense = useMemo(() => {
@@ -214,12 +230,15 @@ const GameStock = () => {
         type: InputTypes.SELECT,
         formKey: "location",
         label: t("Location"),
-        options: locations.map((input) => ({
-          value: input._id,
-          label: input.name,
-        })),
+        options: [...locations]
+          .sort((a, b) => (a.order ?? Infinity) - (b.order ?? Infinity))
+          .map((input) => ({
+            value: input._id,
+            label: input.name,
+          })),
         placeholder: t("Location"),
         required: true,
+        isSortDisabled: true,
       },
       {
         type: InputTypes.NUMBER,
@@ -243,12 +262,16 @@ const GameStock = () => {
               (location) => location._id !== rowToAction?.stockLocation
             )
           : locations
-        )?.map((input) => ({
-          value: input._id,
-          label: input.name,
-        })),
+        )
+          ?.slice()
+          .sort((a, b) => (a.order ?? Infinity) - (b.order ?? Infinity))
+          ?.map((input) => ({
+            value: input._id,
+            label: input.name,
+          })),
         placeholder: t("Location"),
         required: true,
+        isSortDisabled: true,
       },
       {
         type: InputTypes.NUMBER,

--- a/src/components/accounting/Location.tsx
+++ b/src/components/accounting/Location.tsx
@@ -1,4 +1,4 @@
-import { useMemo, useState } from "react";
+import { useEffect, useMemo, useRef, useState } from "react";
 import { useTranslation } from "react-i18next";
 import { FiEdit } from "react-icons/fi";
 import { IoChevronDown, IoChevronUp } from "react-icons/io5";
@@ -9,6 +9,7 @@ import { ActionEnum, DisabledConditionEnum, Location } from "../../types";
 import {
   useGetAllLocations,
   useLocationMutations,
+  useUpdateLocationOrderMutation,
 } from "../../utils/api/location";
 import { useGetDisabledConditions } from "../../utils/api/panelControl/disabledCondition";
 import { useGetPanelControlPages } from "../../utils/api/panelControl/page";
@@ -38,6 +39,7 @@ const LocationPage = () => {
   };
   const [form, setForm] = useState(initialForm as Partial<Location>);
   const { updateLocation, createStockLocation } = useLocationMutations();
+  const { mutate: updateLocationOrder } = useUpdateLocationOrderMutation();
   const disabledConditions = useGetDisabledConditions();
 
   const locationsDisabledCondition = useMemo(() => {
@@ -66,7 +68,46 @@ const LocationPage = () => {
     [t]
   );
 
-  const rows = useMemo(() => locations, [locations]);
+  const rows = useMemo(() => {
+    return [...locations].sort(
+      (a, b) => (a.order ?? Infinity) - (b.order ?? Infinity)
+    );
+  }, [locations]);
+
+  const [localRows, setLocalRows] = useState<Location[]>([]);
+  const localRowsRef = useRef<Location[]>([]);
+
+  useEffect(() => {
+    setLocalRows(rows);
+    localRowsRef.current = rows;
+  }, [rows]);
+
+  const handleDragHover = (dragRow: Location, hoverRow: Location) => {
+    setLocalRows((prev) => {
+      const dragIndex = prev.findIndex((r) => r._id === dragRow._id);
+      const hoverIndex = prev.findIndex((r) => r._id === hoverRow._id);
+      if (dragIndex === -1 || hoverIndex === -1 || dragIndex === hoverIndex)
+        return prev;
+      const next = [...prev];
+      const [removed] = next.splice(dragIndex, 1);
+      next.splice(hoverIndex, 0, removed);
+      localRowsRef.current = next;
+      return next;
+    });
+  };
+
+  const handleDrag = (dragRow: Location) => {
+    const dragIndex = localRowsRef.current.findIndex(
+      (r) => r._id === dragRow._id
+    );
+    if (dragIndex === -1) return;
+    const originalAtPosition = rows[dragIndex];
+    if (!originalAtPosition || originalAtPosition._id === dragRow._id) return;
+    updateLocationOrder({
+      id: dragRow._id,
+      newOrder: originalAtPosition.order ?? 0,
+    });
+  };
 
   const columns = useMemo(() => {
     const cols = [
@@ -651,10 +692,15 @@ const LocationPage = () => {
           rowKeys={rowKeys}
           actions={actions}
           columns={columns}
-          rows={rows}
+          rows={localRows}
           title={t("Locations")}
           addButton={addButton}
           isActionsActive={true}
+          isDraggable={true}
+          onDragHover={(dragRow: Location, hoverRow) =>
+            handleDragHover(dragRow, hoverRow)
+          }
+          onDragEnter={(dragRow: Location) => handleDrag(dragRow)}
         />
       </div>
     </>

--- a/src/components/accounting/Location.tsx
+++ b/src/components/accounting/Location.tsx
@@ -101,12 +101,15 @@ const LocationPage = () => {
       (r) => r._id === dragRow._id
     );
     if (dragIndex === -1) return;
+    const originalIndex = rows.findIndex((r) => r._id === dragRow._id);
+    if (dragIndex === originalIndex) return;
     const originalAtPosition = rows[dragIndex];
-    if (!originalAtPosition || originalAtPosition._id === dragRow._id) return;
-    updateLocationOrder({
-      id: dragRow._id,
-      newOrder: originalAtPosition.order ?? 0,
-    });
+    if (!originalAtPosition) return;
+    const newOrder =
+      dragRow.order === undefined || dragRow.order === null
+        ? (rows[dragIndex - 1]?.order ?? 0) + 1
+        : originalAtPosition.order ?? 0;
+    updateLocationOrder({ id: dragRow._id, newOrder });
   };
 
   const columns = useMemo(() => {

--- a/src/components/accounting/Stock.tsx
+++ b/src/components/accounting/Stock.tsx
@@ -171,7 +171,19 @@ const Stock = () => {
       return acc;
     }, {});
 
-    return Object.values(processedRows || {});
+    return Object.values(processedRows || {}).map((row: any) => ({
+      ...row,
+      collapsible: {
+        ...row.collapsible,
+        collapsibleRows: [...row.collapsible.collapsibleRows].sort((a, b) => {
+          const orderA =
+            locations.find((l) => l._id === a.stockLocation)?.order ?? Infinity;
+          const orderB =
+            locations.find((l) => l._id === b.stockLocation)?.order ?? Infinity;
+          return orderA - orderB;
+        }),
+      },
+    }));
   }, [filteredStocks, products, items, locations, t, isActionsVisible]);
 
   const generalTotalExpense = useMemo(() => {
@@ -200,14 +212,15 @@ const Stock = () => {
         type: InputTypes.SELECT,
         formKey: "location",
         label: t("Location"),
-        options: locations.map((input) => {
-          return {
+        options: [...locations]
+          .sort((a, b) => (a.order ?? Infinity) - (b.order ?? Infinity))
+          .map((input) => ({
             value: input._id,
             label: input.name,
-          };
-        }),
+          })),
         placeholder: t("Location"),
         required: true,
+        isSortDisabled: true,
       },
       {
         type: InputTypes.NUMBER,
@@ -231,14 +244,16 @@ const Stock = () => {
               (location) => location?._id !== rowToAction?.stockLocation
             )
           : locations
-        )?.map((input) => {
-          return {
+        )
+          ?.slice()
+          .sort((a, b) => (a.order ?? Infinity) - (b.order ?? Infinity))
+          ?.map((input) => ({
             value: input._id,
             label: input.name,
-          };
-        }),
+          })),
         placeholder: t("Location"),
         required: true,
+        isSortDisabled: true,
       },
       {
         type: InputTypes.NUMBER,

--- a/src/components/panelComponents/Tables/GenericTable.tsx
+++ b/src/components/panelComponents/Tables/GenericTable.tsx
@@ -55,6 +55,7 @@ type Props<T> = {
   rows: any[];
   isDraggable?: boolean;
   onDragEnter?: (DraggedRow: T, TargetRow: T) => void;
+  onDragHover?: (DraggedRow: T, TargetRow: T) => void;
   isActionsActive: boolean;
   columns: ColumnType[];
   isCollapsible?: boolean;
@@ -109,6 +110,7 @@ const GenericTable = <T,>({
   isColumnFilter = true,
   collapsibleActions,
   onDragEnter,
+  onDragHover,
   outsideSortProps,
   outsideSearchProps,
   isSearch = true,
@@ -291,20 +293,35 @@ const GenericTable = <T,>({
     setSortConfigKey({ key, direction });
   };
 
+  const draggedRowRef = useRef<T | null>(null);
+  const dragOverRowIdRef = useRef<string | null>(null);
+
   const handleDragStart = (
     e: React.DragEvent<HTMLTableRowElement>,
     draggedRow: T
   ) => {
     e.dataTransfer.setData("draggedRow", JSON.stringify(draggedRow));
+    draggedRowRef.current = draggedRow;
   };
   const handleDragOver = (e: React.DragEvent<HTMLTableRowElement>) => {
     e.preventDefault();
+  };
+  const handleDragEnterRow = (
+    _e: React.DragEvent<HTMLTableRowElement>,
+    targetRow: T,
+    rowId: string
+  ) => {
+    if (!onDragHover || !draggedRowRef.current) return;
+    if (dragOverRowIdRef.current === rowId) return;
+    dragOverRowIdRef.current = rowId;
+    onDragHover(draggedRowRef.current, targetRow);
   };
   const handleDrop = (
     e: React.DragEvent<HTMLTableRowElement>,
     targetRow: T
   ) => {
     e.preventDefault();
+    dragOverRowIdRef.current = null;
     const draggedRowData = e.dataTransfer.getData("draggedRow");
     const draggedRow: T = JSON.parse(draggedRowData);
     if (onDragEnter) onDragEnter(draggedRow, targetRow);
@@ -501,6 +518,7 @@ const GenericTable = <T,>({
           draggable={isDraggable}
           onDragStart={(e) => handleDragStart(e, row)}
           onDragOver={handleDragOver}
+          onDragEnter={(e) => handleDragEnterRow(e, row, rowId)}
           onDrop={(e) => handleDrop(e, row)}
           className={`${
             rowIndex !== currentRows.length - 1 && !isRowExpanded

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -182,6 +182,7 @@ export type Location = {
   phoneNumber?: string;
   fallbackStockLocation?: number;
   googleMapsUrl?: string;
+  order?: number;
   dailyHours?: {
     day: string;
     openingTime?: string;

--- a/src/utils/api/location.ts
+++ b/src/utils/api/location.ts
@@ -1,4 +1,7 @@
+import { useMutation, useQueryClient } from "@tanstack/react-query";
+import { toast } from "react-toastify";
 import { Location } from "../../types";
+import { patch } from "./index";
 import { Paths, useGetList, useMutationApi } from "./factory";
 
 const baseUrl = Paths.Location;
@@ -32,4 +35,37 @@ export function useGetSellLocations() {
 export function useGetAllLocations() {
   const url = `${Paths.Location}/all`;
   return useGetList<Location>(url);
+}
+
+export function updateLocationOrder({
+  id,
+  newOrder,
+}: {
+  id: number;
+  newOrder: number;
+}) {
+  return patch({
+    path: `${Paths.Location}/order/${id}`,
+    payload: { newOrder },
+  });
+}
+
+export function useUpdateLocationOrderMutation() {
+  const queryKey = [`${Paths.Location}/all`];
+  const queryClient = useQueryClient();
+  return useMutation({
+    mutationFn: updateLocationOrder,
+    onMutate: async () => {
+      await queryClient.cancelQueries({ queryKey });
+    },
+    onError: (_err: any) => {
+      const errorMessage =
+        _err?.response?.data?.message || "An unexpected error occurred";
+      setTimeout(() => toast.error(errorMessage), 200);
+      queryClient.invalidateQueries({ queryKey });
+    },
+    onSettled: async () => {
+      await queryClient.invalidateQueries({ queryKey });
+    },
+  });
 }


### PR DESCRIPTION
- Location tipine order alanı eklendi
- Lokasyonlar sayfasında satırlar order değerine göre sıralanıyor
- Lokasyonlar sayfasında satırlar sürükle-bırak ile yeniden sıralanabiliyor; sürükleme esnasında satırlar anlık olarak yer değiştiriyor
- Stock sayfasında ürün satırı açıldığında gelen lokasyon listesi order'a göre sıralı görünüyor
- Stock sayfasındaki "Add Stock" ve "Transfer" modallarındaki lokasyon dropdown'ları order'a göre sıralı görünüyor
- GameStock sayfasında da aynı iyileştirmeler uygulandı (collapsible lokasyon listesi ve modaldaki dropdown'lar)