### PR TITLE
refactor: stok sayfalari ortak useStockTableMode hook'una tasindi

### DIFF
--- a/src/components/accounting/GameStock.tsx
+++ b/src/components/accounting/GameStock.tsx
@@ -6,6 +6,7 @@ import { TbTransferIn } from "react-icons/tb";
 import { toast } from "react-toastify";
 import { useFilterContext } from "../../context/Filter.context";
 import { useUserContext } from "../../context/User.context";
+import { useStockTableMode } from "../../hooks/useStockTableMode";
 import {
   ActionEnum,
   DateRangeKey,
@@ -129,72 +130,6 @@ const GameStock = () => {
       });
   }, [stocks, filterGameStockPanelFormElements, products]);
 
-  const rows = useMemo(() => {
-    const processedRows = filteredStocks?.reduce((acc: any, stock) => {
-      const rowProduct = getItem(stock?.product, products);
-      const rowItem = getItem(rowProduct?.matchedMenuItem, items);
-      const productName = rowProduct?.name;
-      const locationName = getItem(stock?.location, locations)?.name;
-      const unitPrice = rowProduct?.unitPrice ?? 0;
-      const quantity = stock?.quantity;
-      const totalPrice = parseFloat((unitPrice * quantity)?.toFixed(1));
-      if (!productName) {
-        return acc;
-      }
-      if (!acc[productName]) {
-        acc[productName] = {
-          ...stock,
-          prdct: productName,
-          sku: rowItem?.sku ?? "",
-          barcode: rowItem?.barcode ?? "",
-          unitPrice,
-          menuPrice: rowItem?.price ?? "",
-          onlineMenuPrice: rowItem?.onlinePrice ?? "",
-          totalGroupPrice: 0,
-          totalQuantity: 0,
-          collapsible: {
-            collapsibleColumns: [
-              { key: t("Location"), isSortable: true },
-              { key: t("Quantity"), isSortable: true },
-              isGameStockEnableEdit
-                ? { key: t("Actions"), isSortable: false }
-                : undefined,
-            ].filter(Boolean),
-            collapsibleRowKeys: [{ key: "location" }, { key: "quantity" }],
-            collapsibleRows: [],
-          },
-        };
-      }
-      acc[productName].totalGroupPrice += totalPrice;
-      acc[productName].totalQuantity += quantity;
-      acc[productName].collapsible.collapsibleRows.push({
-        stockId: stock?._id,
-        stockProduct: stock?.product,
-        stockLocation: stock?.location,
-        stockQuantity: stock?.quantity,
-        stockUnitPrice: rowProduct?.unitPrice ?? 0,
-        location: locationName,
-        quantity: quantity,
-        totalPrice: totalPrice,
-      });
-
-      return acc;
-    }, {});
-
-    return Object.values(processedRows || {}).sort(
-      (a, b) =>
-        (b as { totalQuantity: number }).totalQuantity -
-        (a as { totalQuantity: number }).totalQuantity
-    );
-  }, [filteredStocks, products, items, locations, t, isGameStockEnableEdit]);
-
-  const generalTotalExpense = useMemo(() => {
-    return (rows?.reduce((acc: number, stock: any) => {
-      const expense = parseFloat(stock?.totalGroupPrice?.toFixed(1) || "0");
-      return acc + expense;
-    }, 0) || 0) as number;
-  }, [rows]);
-
   const inputs = useMemo(
     () => [
       {
@@ -316,6 +251,22 @@ const GameStock = () => {
     }
     return cols;
   }, [t, gameStockPageDisabledCondition, user, showGameStockPrices]);
+
+  const {
+    rows,
+    columns: tableColumns,
+    generalTotalExpense,
+    getTableModeProps,
+  } = useStockTableMode({
+    filteredStocks,
+    products,
+    items,
+    locations,
+    locationFilter: filterGameStockPanelFormElements?.location,
+    isEnableEdit: isGameStockEnableEdit,
+    columns,
+    sortByTotalQuantity: true,
+  });
 
   const rowKeys = useMemo(() => {
     const keys = [
@@ -766,15 +717,13 @@ const GameStock = () => {
       <div className="w-[95%] mx-auto ">
         <GenericTable
           rowKeys={rowKeys}
-          collapsibleActions={isGameStockEnableEdit ? collapsibleActions : []}
+          {...getTableModeProps(collapsibleActions)}
           filters={filters}
-          columns={columns}
+          columns={tableColumns}
           rows={rows}
           title={t("Game Stocks")}
           addButton={addButton}
           filterPanel={filterPanel}
-          isActionsActive={isGameStockEnableEdit}
-          isCollapsible={true}
           isToolTipEnabled={false}
           isExcel={
             user &&

--- a/src/components/accounting/SandwichStock.tsx
+++ b/src/components/accounting/SandwichStock.tsx
@@ -6,6 +6,7 @@ import { TbTransferIn } from "react-icons/tb";
 import { toast } from "react-toastify";
 import { useFilterContext } from "../../context/Filter.context";
 import { useUserContext } from "../../context/User.context";
+import { useStockTableMode } from "../../hooks/useStockTableMode";
 import {
   ActionEnum,
   DateRangeKey,
@@ -23,7 +24,7 @@ import {
 } from "../../utils/api/account/stock";
 import { useGetAccountVendors } from "../../utils/api/account/vendor";
 import { dateRanges } from "../../utils/api/dateRanges";
-import { useGetStockLocations } from "../../utils/api/location";
+import { useGetStoreLocations } from "../../utils/api/location";
 import { useGetCategories } from "../../utils/api/menu/category";
 import { useGetMenuItems } from "../../utils/api/menu/menu-item";
 import { useGetDisabledConditions } from "../../utils/api/panelControl/disabledCondition";
@@ -61,7 +62,7 @@ const SandwichStock = () => {
   const items = useGetMenuItems();
   const vendors = useGetAccountVendors();
   const brands = useGetAccountBrands();
-  const locations = useGetStockLocations();
+  const locations = useGetStoreLocations();
   const disabledConditions = useGetDisabledConditions();
   const [isAddModalOpen, setIsAddModalOpen] = useState(false);
   const [isEditModalOpen, setIsEditModalOpen] = useState(false);
@@ -131,79 +132,6 @@ const SandwichStock = () => {
         );
       });
   }, [stocks, filterSandwichStockPanelFormElements, products]);
-
-  const rows = useMemo(() => {
-    const processedRows = filteredStocks?.reduce((acc: any, stock) => {
-      const rowProduct = getItem(stock?.product, products);
-      const rowItem = getItem(rowProduct?.matchedMenuItem, items);
-      const productName = rowProduct?.name;
-      const locationName = getItem(stock?.location, locations)?.name;
-      const unitPrice = rowProduct?.unitPrice ?? 0;
-      const quantity = stock?.quantity;
-      const totalPrice = parseFloat((unitPrice * quantity)?.toFixed(1));
-      if (!productName) {
-        return acc;
-      }
-      if (!acc[productName]) {
-        acc[productName] = {
-          ...stock,
-          prdct: productName,
-          sku: rowItem?.sku ?? "",
-          barcode: rowItem?.barcode ?? "",
-          unitPrice,
-          menuPrice: rowItem?.price ?? "",
-          onlineMenuPrice: rowItem?.onlinePrice ?? "",
-          totalGroupPrice: 0,
-          totalQuantity: 0,
-          collapsible: {
-            collapsibleColumns: [
-              { key: t("Location"), isSortable: true },
-              { key: t("Quantity"), isSortable: true },
-              isSandwichStockEnableEdit
-                ? { key: t("Actions"), isSortable: false }
-                : undefined,
-            ].filter(Boolean),
-            collapsibleRowKeys: [{ key: "location" }, { key: "quantity" }],
-            collapsibleRows: [],
-          },
-        };
-      }
-      acc[productName].totalGroupPrice += totalPrice;
-      acc[productName].totalQuantity += quantity;
-      acc[productName].collapsible.collapsibleRows.push({
-        stockId: stock?._id,
-        stockProduct: stock?.product,
-        stockLocation: stock?.location,
-        stockQuantity: stock?.quantity,
-        stockUnitPrice: rowProduct?.unitPrice ?? 0,
-        location: locationName,
-        quantity: quantity,
-        totalPrice: totalPrice,
-      });
-
-      return acc;
-    }, {});
-
-    return Object.values(processedRows || {}).sort(
-      (a, b) =>
-        (b as { totalQuantity: number }).totalQuantity -
-        (a as { totalQuantity: number }).totalQuantity
-    );
-  }, [
-    filteredStocks,
-    products,
-    items,
-    locations,
-    t,
-    isSandwichStockEnableEdit,
-  ]);
-
-  const generalTotalExpense = useMemo(() => {
-    return (rows?.reduce((acc: number, stock: any) => {
-      const expense = parseFloat(stock?.totalGroupPrice?.toFixed(1) || "0");
-      return acc + expense;
-    }, 0) || 0) as number;
-  }, [rows]);
 
   const inputs = useMemo(
     () => [
@@ -326,6 +254,23 @@ const SandwichStock = () => {
     }
     return cols;
   }, [t, sandwichStockPageDisabledCondition, user, showSandwichStockPrices]);
+
+  const {
+    rows,
+    columns: tableColumns,
+    generalTotalExpense,
+    getTableModeProps,
+  } = useStockTableMode({
+    filteredStocks,
+    products,
+    items,
+    locations,
+    locationFilter: filterSandwichStockPanelFormElements?.location,
+    isEnableEdit: isSandwichStockEnableEdit,
+    columns,
+    sortByTotalQuantity: true,
+    requireLocationName: true,
+  });
 
   const rowKeys = useMemo(() => {
     const keys = [
@@ -776,17 +721,13 @@ const SandwichStock = () => {
       <div className="w-[95%] mx-auto ">
         <GenericTable
           rowKeys={rowKeys}
-          collapsibleActions={
-            isSandwichStockEnableEdit ? collapsibleActions : []
-          }
+          {...getTableModeProps(collapsibleActions)}
           filters={filters}
-          columns={columns}
+          columns={tableColumns}
           rows={rows}
           title={t("Sandwich Stocks")}
           addButton={addButton}
           filterPanel={filterPanel}
-          isActionsActive={isSandwichStockEnableEdit}
-          isCollapsible={true}
           isToolTipEnabled={false}
           isExcel={
             user &&

--- a/src/components/accounting/Stock.tsx
+++ b/src/components/accounting/Stock.tsx
@@ -6,6 +6,7 @@ import { TbTransferIn } from "react-icons/tb";
 import { toast } from "react-toastify";
 import { useFilterContext } from "../../context/Filter.context";
 import { useUserContext } from "../../context/User.context";
+import { useStockTableMode } from "../../hooks/useStockTableMode";
 import {
   ActionEnum,
   DateRangeKey,
@@ -96,9 +97,6 @@ const Stock = () => {
     return getItem(DisabledConditionEnum.STOCK_STOCK, disabledConditions);
   }, [disabledConditions]);
 
-  const isActionsVisible =
-    isStockEnableEdit || !!filterStockPanelFormElements?.location;
-
   const filteredStocks = useMemo(() => {
     return stocks?.filter((stock) => {
       const rowProduct = getItem(stock?.product, products);
@@ -119,67 +117,6 @@ const Stock = () => {
       );
     });
   }, [stocks, filterStockPanelFormElements, products]);
-
-  const rows = useMemo(() => {
-    const processedRows = filteredStocks?.reduce((acc: any, stock) => {
-      const rowProduct = getItem(stock?.product, products);
-      const rowItem = getItem(rowProduct?.matchedMenuItem, items);
-      const productName = rowProduct?.name;
-      const locationName = getItem(stock?.location, locations)?.name;
-      const unitPrice = rowProduct?.unitPrice ?? 0;
-      const quantity = stock?.quantity;
-      const totalPrice = parseFloat((unitPrice * quantity)?.toFixed(1));
-      if (!productName) {
-        return acc;
-      }
-      if (!acc[productName]) {
-        acc[productName] = {
-          ...stock,
-          sku: rowItem?.sku ?? "",
-          barcode: rowItem?.barcode ?? "",
-          prdct: productName,
-          unitPrice,
-          menuPrice: rowItem?.price ?? "",
-          totalGroupPrice: 0,
-          totalQuantity: 0,
-          collapsible: {
-            collapsibleColumns: [
-              { key: t("Location"), isSortable: true },
-              { key: t("Quantity"), isSortable: true },
-              isActionsVisible
-                ? { key: t("Actions"), isSortable: false }
-                : undefined,
-            ].filter(Boolean),
-            collapsibleRowKeys: [{ key: "location" }, { key: "quantity" }],
-            collapsibleRows: [],
-          },
-        };
-      }
-      acc[productName].totalGroupPrice += totalPrice;
-      acc[productName].totalQuantity += quantity;
-      acc[productName].collapsible.collapsibleRows.push({
-        stockId: stock?._id,
-        stockProduct: stock?.product,
-        stockLocation: stock?.location,
-        stockQuantity: stock?.quantity,
-        stockUnitPrice: rowProduct?.unitPrice ?? 0,
-        location: locationName,
-        quantity: quantity,
-        totalPrice: totalPrice,
-      });
-
-      return acc;
-    }, {});
-
-    return Object.values(processedRows || {});
-  }, [filteredStocks, products, items, locations, t, isActionsVisible]);
-
-  const generalTotalExpense = useMemo(() => {
-    return (rows?.reduce((acc: number, stock: any) => {
-      const expense = parseFloat(stock?.totalGroupPrice?.toFixed(1) || "0");
-      return acc + expense;
-    }, 0) || 0) as number;
-  }, [rows]);
 
   const inputs = useMemo(
     () => [
@@ -297,6 +234,21 @@ const Stock = () => {
     }
     return cols;
   }, [t, stockPageDisabledCondition, user, showStockPrices]);
+
+  const {
+    rows,
+    columns: tableColumns,
+    generalTotalExpense,
+    getTableModeProps,
+  } = useStockTableMode({
+    filteredStocks,
+    products,
+    items,
+    locations,
+    locationFilter: filterStockPanelFormElements?.location,
+    isEnableEdit: isStockEnableEdit,
+    columns,
+  });
 
   const rowKeys = useMemo(() => {
     const keys = [
@@ -769,15 +721,13 @@ const Stock = () => {
       <div className="w-full px-4 my-6">
         <GenericTable
           rowKeys={rowKeys}
-          collapsibleActions={isActionsVisible ? collapsibleActions : []}
+          {...getTableModeProps(collapsibleActions)}
           filters={filters}
-          columns={columns}
+          columns={tableColumns}
           rows={rows}
           title={t("Product Stocks")}
           addButton={addButton}
           filterPanel={filterPanel}
-          isActionsActive={isActionsVisible}
-          isCollapsible={true}
           isSearch={true}
           isToolTipEnabled={false}
           isExcel={

--- a/src/components/stocks/ColdDrinkStocks.tsx
+++ b/src/components/stocks/ColdDrinkStocks.tsx
@@ -6,6 +6,7 @@ import { TbTransferIn } from "react-icons/tb";
 import { toast } from "react-toastify";
 import { useFilterContext } from "../../context/Filter.context";
 import { useUserContext } from "../../context/User.context";
+import { useStockTableMode } from "../../hooks/useStockTableMode";
 import {
   ActionEnum,
   COLDDRINKEXPENSETYPE,
@@ -123,77 +124,6 @@ const ColdDrinkStock = () => {
       });
   }, [stocks, filterColdDrinkStockPanelFormElements, products]);
 
-  const rows = useMemo(() => {
-    const processedRows = filteredStocks?.reduce((acc: any, stock) => {
-      const rowProduct = getItem(stock?.product, products);
-      const rowItem = getItem(rowProduct?.matchedMenuItem, items);
-      const productName = rowProduct?.name;
-      const locationName = getItem(stock?.location, locations)?.name;
-      const unitPrice = rowProduct?.unitPrice ?? 0;
-      const quantity = stock?.quantity;
-      const totalPrice = parseFloat((unitPrice * quantity)?.toFixed(1));
-      if (!productName || !locationName) {
-        return acc;
-      }
-      if (!acc[productName]) {
-        acc[productName] = {
-          ...stock,
-          prdct: productName,
-          unitPrice,
-          menuPrice: rowItem?.price ?? "",
-          onlineMenuPrice: rowItem?.onlinePrice ?? "",
-          totalGroupPrice: 0,
-          totalQuantity: 0,
-          collapsible: {
-            collapsibleColumns: [
-              { key: t("Location"), isSortable: true },
-              { key: t("Quantity"), isSortable: true },
-              isColdDrinkStockEnableEdit
-                ? { key: t("Actions"), isSortable: false }
-                : undefined,
-            ].filter(Boolean),
-            collapsibleRowKeys: [{ key: "location" }, { key: "quantity" }],
-            collapsibleRows: [],
-          },
-        };
-      }
-      acc[productName].totalGroupPrice += totalPrice;
-      acc[productName].totalQuantity += quantity;
-      acc[productName].collapsible.collapsibleRows.push({
-        stockId: stock?._id,
-        stockProduct: stock?.product,
-        stockLocation: stock?.location,
-        stockQuantity: stock?.quantity,
-        stockUnitPrice: rowProduct?.unitPrice ?? 0,
-        location: locationName,
-        quantity: quantity,
-        totalPrice: totalPrice,
-      });
-
-      return acc;
-    }, {});
-
-    return Object.values(processedRows || {}).sort(
-      (a, b) =>
-        (b as { totalQuantity: number }).totalQuantity -
-        (a as { totalQuantity: number }).totalQuantity
-    );
-  }, [
-    filteredStocks,
-    products,
-    items,
-    locations,
-    t,
-    isColdDrinkStockEnableEdit,
-  ]);
-
-  const generalTotalExpense = useMemo(() => {
-    return (rows?.reduce((acc: number, stock: any) => {
-      const expense = parseFloat(stock?.totalGroupPrice?.toFixed(1) || "0");
-      return acc + expense;
-    }, 0) || 0) as number;
-  }, [rows]);
-
   const inputs = useMemo(
     () => [
       {
@@ -310,6 +240,23 @@ const ColdDrinkStock = () => {
     }
     return cols;
   }, [t, coldDrinkStockPageDisabledCondition, user, showColdDrinkStockPrices]);
+
+  const {
+    rows,
+    columns: tableColumns,
+    generalTotalExpense,
+    getTableModeProps,
+  } = useStockTableMode({
+    filteredStocks,
+    products,
+    items,
+    locations,
+    locationFilter: filterColdDrinkStockPanelFormElements?.location,
+    isEnableEdit: isColdDrinkStockEnableEdit,
+    columns,
+    sortByTotalQuantity: true,
+    requireLocationName: true,
+  });
 
   const rowKeys = useMemo(() => {
     const keys = [
@@ -695,17 +642,13 @@ const ColdDrinkStock = () => {
       <div className="w-[95%] mx-auto ">
         <GenericTable
           rowKeys={rowKeys}
-          collapsibleActions={
-            isColdDrinkStockEnableEdit ? collapsibleActions : []
-          }
+          {...getTableModeProps(collapsibleActions)}
           filters={filters}
-          columns={columns}
+          columns={tableColumns}
           rows={rows}
           title={t("Cold Drink Stocks")}
           addButton={addButton}
           filterPanel={filterPanel}
-          isActionsActive={isColdDrinkStockEnableEdit}
-          isCollapsible={true}
           isToolTipEnabled={false}
           isExcel={
             user &&

--- a/src/components/stocks/DessertStocks.tsx
+++ b/src/components/stocks/DessertStocks.tsx
@@ -6,6 +6,7 @@ import { TbTransferIn } from "react-icons/tb";
 import { toast } from "react-toastify";
 import { useFilterContext } from "../../context/Filter.context";
 import { useUserContext } from "../../context/User.context";
+import { useStockTableMode } from "../../hooks/useStockTableMode";
 import {
   ActionEnum,
   DESSERTEXPENSETYPE,
@@ -123,70 +124,6 @@ const DessertStock = () => {
         );
       });
   }, [stocks, filterDesertStockPanelFormElements, products]);
-
-  const rows = useMemo(() => {
-    const processedRows = filteredStocks?.reduce((acc: any, stock) => {
-      const rowProduct = getItem(stock?.product, products);
-      const rowItem = getItem(rowProduct?.matchedMenuItem, items);
-      const productName = rowProduct?.name;
-      const locationName = getItem(stock?.location, locations)?.name;
-      const unitPrice = rowProduct?.unitPrice ?? 0;
-      const quantity = stock?.quantity;
-      const totalPrice = parseFloat((unitPrice * quantity)?.toFixed(1));
-      if (!productName || !locationName) {
-        return acc;
-      }
-      if (!acc[productName]) {
-        acc[productName] = {
-          ...stock,
-          prdct: productName,
-          unitPrice,
-          menuPrice: rowItem?.price ?? "",
-          onlineMenuPrice: rowItem?.onlinePrice ?? "",
-          totalGroupPrice: 0,
-          totalQuantity: 0,
-          collapsible: {
-            collapsibleColumns: [
-              { key: t("Location"), isSortable: true },
-              { key: t("Quantity"), isSortable: true },
-              isDesertStockEnableEdit
-                ? { key: t("Actions"), isSortable: false }
-                : undefined,
-            ].filter(Boolean),
-            collapsibleRowKeys: [{ key: "location" }, { key: "quantity" }],
-            collapsibleRows: [],
-          },
-        };
-      }
-      acc[productName].totalGroupPrice += totalPrice;
-      acc[productName].totalQuantity += quantity;
-      acc[productName].collapsible.collapsibleRows.push({
-        stockId: stock?._id,
-        stockProduct: stock?.product,
-        stockLocation: stock?.location,
-        stockQuantity: stock?.quantity,
-        stockUnitPrice: rowProduct?.unitPrice ?? 0,
-        location: locationName,
-        quantity: quantity,
-        totalPrice: totalPrice,
-      });
-
-      return acc;
-    }, {});
-
-    return Object.values(processedRows || {}).sort(
-      (a, b) =>
-        (b as { totalQuantity: number }).totalQuantity -
-        (a as { totalQuantity: number }).totalQuantity
-    );
-  }, [filteredStocks, products, items, locations, t, isDesertStockEnableEdit]);
-
-  const generalTotalExpense = useMemo(() => {
-    return (rows?.reduce((acc: number, stock: any) => {
-      const expense = parseFloat(stock?.totalGroupPrice?.toFixed(1) || "0");
-      return acc + expense;
-    }, 0) || 0) as number;
-  }, [rows]);
 
   const inputs = useMemo(
     () => [
@@ -306,6 +243,23 @@ const DessertStock = () => {
     }
     return cols;
   }, [t, dessertStockPageDisabledCondition, user, showDesertStockPrices]);
+
+  const {
+    rows,
+    columns: tableColumns,
+    generalTotalExpense,
+    getTableModeProps,
+  } = useStockTableMode({
+    filteredStocks,
+    products,
+    items,
+    locations,
+    locationFilter: filterDesertStockPanelFormElements?.location,
+    isEnableEdit: isDesertStockEnableEdit,
+    columns,
+    sortByTotalQuantity: true,
+    requireLocationName: true,
+  });
 
   const rowKeys = useMemo(() => {
     const keys = [
@@ -693,15 +647,13 @@ const DessertStock = () => {
       <div className="w-[95%] mx-auto ">
         <GenericTable
           rowKeys={rowKeys}
-          collapsibleActions={isDesertStockEnableEdit ? collapsibleActions : []}
+          {...getTableModeProps(collapsibleActions)}
           filters={filters}
-          columns={columns}
+          columns={tableColumns}
           rows={rows}
           title={t("Dessert Stocks")}
           addButton={addButton}
           filterPanel={filterPanel}
-          isActionsActive={isDesertStockEnableEdit}
-          isCollapsible={true}
           isToolTipEnabled={false}
           isExcel={
             user &&

--- a/src/hooks/useStockTableMode.ts
+++ b/src/hooks/useStockTableMode.ts
@@ -1,0 +1,181 @@
+import { useCallback, useMemo } from "react";
+import { useTranslation } from "react-i18next";
+import { ActionType } from "../components/panelComponents/shared/types";
+import { AccountProduct, AccountStock, Location, MenuItem } from "../types";
+import { getItem } from "../utils/getItem";
+
+const EMPTY_ACTIONS: never[] = [];
+
+type StockTableColumn = {
+  key: string;
+  isSortable: boolean;
+  correspondingKey?: string;
+};
+
+type UseStockTableModeProps = {
+  filteredStocks: AccountStock[] | undefined;
+  products: AccountProduct[];
+  items: MenuItem[];
+  locations: Location[];
+  locationFilter: AccountStock["location"] | "";
+  isEnableEdit: boolean;
+  columns: StockTableColumn[];
+  sortByTotalQuantity?: boolean;
+  requireLocationName?: boolean;
+};
+
+export const useStockTableMode = ({
+  filteredStocks,
+  products,
+  items,
+  locations,
+  locationFilter,
+  isEnableEdit,
+  columns,
+  sortByTotalQuantity = false,
+  requireLocationName = false,
+}: UseStockTableModeProps) => {
+  const { t } = useTranslation();
+  const isLocationFilterActive = !!locationFilter;
+
+  const rows = useMemo(() => {
+    const deriveStockFields = (stock: AccountStock) => {
+      const rowProduct = getItem(stock?.product, products);
+      const rowItem = getItem(rowProduct?.matchedMenuItem, items);
+      const unitPrice = rowProduct?.unitPrice ?? 0;
+      const quantity = stock?.quantity;
+      return {
+        rowItem,
+        productName: rowProduct?.name,
+        unitPrice,
+        quantity,
+        totalPrice: parseFloat((unitPrice * quantity)?.toFixed(1)),
+      };
+    };
+
+    if (isLocationFilterActive) {
+      return (
+        filteredStocks
+          ?.map((stock) => {
+            const { rowItem, productName, unitPrice, quantity, totalPrice } =
+              deriveStockFields(stock);
+            if (!productName) return null;
+            return {
+              ...stock,
+              prdct: productName,
+              sku: rowItem?.sku ?? "",
+              barcode: rowItem?.barcode ?? "",
+              totalQuantity: quantity,
+              unitPrice,
+              menuPrice: rowItem?.price ?? "",
+              onlineMenuPrice: rowItem?.onlinePrice ?? "",
+              totalGroupPrice: totalPrice,
+              stockId: stock?._id,
+              stockProduct: stock?.product,
+              stockLocation: stock?.location,
+              stockQuantity: quantity,
+            };
+          })
+          .filter(Boolean) ?? []
+      );
+    }
+
+    const processedRows = filteredStocks?.reduce((acc: any, stock) => {
+      const { rowItem, productName, unitPrice, quantity, totalPrice } =
+        deriveStockFields(stock);
+      const locationName = getItem(stock?.location, locations)?.name;
+      if (!productName || (requireLocationName && !locationName)) {
+        return acc;
+      }
+      if (!acc[productName]) {
+        acc[productName] = {
+          ...stock,
+          prdct: productName,
+          sku: rowItem?.sku ?? "",
+          barcode: rowItem?.barcode ?? "",
+          unitPrice,
+          menuPrice: rowItem?.price ?? "",
+          onlineMenuPrice: rowItem?.onlinePrice ?? "",
+          totalGroupPrice: 0,
+          totalQuantity: 0,
+          collapsible: {
+            collapsibleColumns: [
+              { key: t("Location"), isSortable: true },
+              { key: t("Quantity"), isSortable: true },
+              isEnableEdit
+                ? { key: t("Actions"), isSortable: false }
+                : undefined,
+            ].filter(Boolean),
+            collapsibleRowKeys: [{ key: "location" }, { key: "quantity" }],
+            collapsibleRows: [],
+          },
+        };
+      }
+      acc[productName].totalGroupPrice += totalPrice;
+      acc[productName].totalQuantity += quantity;
+      acc[productName].collapsible.collapsibleRows.push({
+        stockId: stock?._id,
+        stockProduct: stock?.product,
+        stockLocation: stock?.location,
+        stockQuantity: stock?.quantity,
+        stockUnitPrice: unitPrice,
+        location: locationName,
+        quantity: quantity,
+        totalPrice: totalPrice,
+      });
+
+      return acc;
+    }, {});
+
+    const groupedRows = Object.values(processedRows || {});
+    if (sortByTotalQuantity) {
+      return groupedRows.sort(
+        (a, b) =>
+          (b as { totalQuantity: number }).totalQuantity -
+          (a as { totalQuantity: number }).totalQuantity
+      );
+    }
+    return groupedRows;
+  }, [
+    filteredStocks,
+    products,
+    items,
+    locations,
+    t,
+    isEnableEdit,
+    isLocationFilterActive,
+    sortByTotalQuantity,
+    requireLocationName,
+  ]);
+
+  const columnsWithActions = useMemo(() => {
+    if (!isLocationFilterActive) return columns;
+    return [...columns, { key: t("Actions"), isSortable: false }];
+  }, [columns, isLocationFilterActive, t]);
+
+  const generalTotalExpense = useMemo(() => {
+    return (rows?.reduce((acc: number, stock: any) => {
+      const expense = parseFloat(stock?.totalGroupPrice?.toFixed(1) || "0");
+      return acc + expense;
+    }, 0) || 0) as number;
+  }, [rows]);
+
+  const getTableModeProps = useCallback(
+    <T,>(actions: ActionType<T>[]) => ({
+      actions: isLocationFilterActive ? actions : undefined,
+      collapsibleActions:
+        !isLocationFilterActive && isEnableEdit ? actions : EMPTY_ACTIONS,
+      isActionsActive: isLocationFilterActive || isEnableEdit,
+      isCollapsible: !isLocationFilterActive,
+    }),
+    [isLocationFilterActive, isEnableEdit]
+  );
+
+  return {
+    rows,
+    columns: columnsWithActions,
+    isLocationFilterActive,
+    generalTotalExpense,
+    getTableModeProps,
+  };
+};


### PR DESCRIPTION
- Stock, GameStock, SandwichStock, ColdDrinkStocks ve DessertStocks sayfalarinda tekrarlanan satir gruplama, toplam hesaplama ve tablo modu mantigi tek hook'ta (useStockTableMode) birlestirildi
- Konum filtresi seciliyken tablolar collapsible yapidan duz (flat) yapiya gecip satir bazinda aksiyon butonlarini gosteriyor
- SandwichStock konum kaynagi magaza konumlarina (useGetStoreLocations) cevrildi; konum adi bulunamayan depo stoklari requireLocationName ile liste ve toplamlardan cikarildi