### PR TITLE
EnterConsumption sayfasında ondalık sayı ve filtre düzeltmesi

### DIFF
--- a/src/components/stocks/EnterConsumption.tsx
+++ b/src/components/stocks/EnterConsumption.tsx
@@ -298,6 +298,8 @@ const EnterConsumption = () => {
         placeholder: t("Start Date"),
         required: true,
         isDatePicker: true,
+        invalidateKeys: [{ key: "date", defaultValue: "" }],
+        isOnClearActive: false,
       },
       {
         type: InputTypes.DATE,
@@ -306,6 +308,8 @@ const EnterConsumption = () => {
         placeholder: t("End Date"),
         required: true,
         isDatePicker: true,
+        invalidateKeys: [{ key: "date", defaultValue: "" }],
+        isOnClearActive: false,
       },
     ],
     [expenseTypes, products, vendors, brands, locations, t]
@@ -423,7 +427,7 @@ const EnterConsumption = () => {
         ? [{ key: "productCost", className: "min-w-32 pr-1", isParseFloat: true }]
         : []),
       ...(!isShowPricesDisabled
-        ? [{ key: "currentAmount", className: "min-w-32 pr-1" }]
+        ? [{ key: "currentAmount", className: "min-w-32 pr-1", isParseFloat: true }]
         : []),
       {
         key: "change",

--- a/src/components/stocks/EnterConsumption.tsx
+++ b/src/components/stocks/EnterConsumption.tsx
@@ -30,6 +30,7 @@ import { useGetAllCategories } from "../../utils/api/menu/category";
 import { useGetDisabledConditions } from "../../utils/api/panelControl/disabledCondition";
 import { useGetUsersMinimal } from "../../utils/api/user";
 import { formatAsLocalDate } from "../../utils/format";
+import { formatAmount } from "../../utils/formatValue";
 import { getItem } from "../../utils/getItem";
 import { ConfirmationDialog } from "../common/ConfirmationDialog";
 import GenericAddEditPanel from "../panelComponents/FormElements/GenericAddEditPanel";
@@ -427,7 +428,13 @@ const EnterConsumption = () => {
         ? [{ key: "productCost", className: "min-w-32 pr-1", isParseFloat: true }]
         : []),
       ...(!isShowPricesDisabled
-        ? [{ key: "currentAmount", className: "min-w-32 pr-1", isParseFloat: true }]
+        ? [
+            {
+              key: "currentAmount",
+              className: "min-w-32 pr-1",
+              node: (row: any) => formatAmount(row.currentAmount),
+            },
+          ]
         : []),
       {
         key: "change",


### PR DESCRIPTION
- Eski miktar kolonundaki ondalık sayı formatlandı.
- Filtredeki bozukluk giderildi(Bu Ay default iken, mesela başlangıç bitiş 6 girince hala dışarıda kalan verileri gösteriyordu)