### PR TITLE
Otomatik kapanan ortacılık aktivitesinin raporlarda gösterimi

### DIFF
--- a/src/components/activity/ActivityPayloadRenderer.tsx
+++ b/src/components/activity/ActivityPayloadRenderer.tsx
@@ -404,13 +404,17 @@ const ActivityPayloadRenderer = ({
 
   const isFinishMiddlemanByManager =
     resolvedType === "FINISH_MIDDLEMAN_BY_MANAGER";
-  const summaryLine =
-    isFinishMiddlemanByManager && (actorName || middlemanUserName)
-      ? t("Middleman session of {{name}} closed by {{actor}}", {
-          name: middlemanUserName ?? t("Someone"),
-          actor: actorName ?? t("Someone"),
-        })
-      : null;
+  const isFinishMiddlemanAuto = resolvedType === "FINISH_MIDDLEMAN_AUTO";
+  const summaryLine = isFinishMiddlemanByManager && (actorName || middlemanUserName)
+    ? t("Middleman session of {{name}} closed by {{actor}}", {
+        name: middlemanUserName ?? t("Someone"),
+        actor: actorName ?? t("Someone"),
+      })
+    : isFinishMiddlemanAuto && middlemanUserName
+    ? t("Middleman session of {{name}} closed automatically", {
+        name: middlemanUserName,
+      })
+    : null;
 
   // Parse ve stripVersionKeys tek seferinde yapılıyor — hem shift hem default branch kullanır
   const { action, entity, detailFields, rawPayload, hasReadableDetails, parsedPayload } =

--- a/src/locales/en/translation.json
+++ b/src/locales/en/translation.json
@@ -1393,6 +1393,8 @@
   "Do you want to end middleman session for {{name}}?": "Do you want to end middleman session for {{name}}?",
   "Click to end middleman": "Click to end middleman",
   "Middleman session of {{name}} closed by {{actor}}": "Middleman session of {{name}} closed by {{actor}}",
+  "Middleman session of {{name}} closed automatically": "Middleman session of {{name}} closed automatically",
+  "Finish Middleman Auto": "Finish Middleman Auto",
   "No active middleman session found": "No active middleman session found",
   "Someone": "Someone",
   "is the middleman": "is the middleman",

--- a/src/locales/tr/translation.json
+++ b/src/locales/tr/translation.json
@@ -1404,6 +1404,8 @@
   "Do you want to end middleman session for {{name}}?": "{{name}} için ortacılığı bitirmek istiyor musunuz?",
   "Click to end middleman": "Ortacılığı bitirmek için tıklayın",
   "Middleman session of {{name}} closed by {{actor}}": "Ortacılık {{name}} — {{actor}} tarafından kapatıldı",
+  "Middleman session of {{name}} closed automatically": "{{name}} kullanıcısının ortacılığı otomatik olarak kapatıldı",
+  "Finish Middleman Auto": "Otomatik Ortacılık Bitirme",
   "No active middleman session found": "Aktif ortacılık oturumu bulunamadı",
   "Someone": "Biri",
   "is the middleman": "ortacı",

--- a/src/pages/UserActivities.tsx
+++ b/src/pages/UserActivities.tsx
@@ -85,7 +85,8 @@ const UserActivities = () => {
                   payload: activity.payload,
                   actorName: getItem(activity.user, users)?.name,
                   middlemanUserName:
-                    activity.type === "FINISH_MIDDLEMAN_BY_MANAGER"
+                    activity.type === "FINISH_MIDDLEMAN_BY_MANAGER" ||
+                    activity.type === "FINISH_MIDDLEMAN_AUTO"
                       ? getItem(
                           (activity.payload as { user?: string })?.user,
                           users

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -1899,6 +1899,7 @@ export enum ActivityType {
   START_MIDDLEMAN = "START_MIDDLEMAN",
   FINISH_MIDDLEMAN = "FINISH_MIDDLEMAN",
   FINISH_MIDDLEMAN_BY_MANAGER = "FINISH_MIDDLEMAN_BY_MANAGER",
+  FINISH_MIDDLEMAN_AUTO = "FINISH_MIDDLEMAN_AUTO",
   CREATE_SHIFT = "CREATE_SHIFT",
   UPDATE_SHIFT = "UPDATE_SHIFT",
   DELETE_SHIFT = "DELETE_SHIFT",
@@ -2222,6 +2223,11 @@ export const activityTypeDetails = [
     value: ActivityType.FINISH_MIDDLEMAN_BY_MANAGER,
     label: "Finish Middleman By Manager",
     bgColor: "bg-amber-600",
+  },
+  {
+    value: ActivityType.FINISH_MIDDLEMAN_AUTO,
+    label: "Finish Middleman Auto",
+    bgColor: "bg-gray-500",
   },
   {
     value: ActivityType.CREATE_SHIFT,


### PR DESCRIPTION
Backend tarafında eklenen FINISH_MIDDLEMAN_AUTO aktivite tipi artık aktivite raporlarında ayrı bir etiketle (gri) görünüyor ve detay kartında "X kullanıcısının ortacılığı otomatik olarak kapatıldı" şeklinde okunur bir özetle açılıyor. TR/EN çevirileri eklendi.