### PR TITLE
fix : Profil sayfasi (Ayarlar) checkbox hizalama

### DIFF
--- a/src/components/panelComponents/FormElements/TextInput.tsx
+++ b/src/components/panelComponents/FormElements/TextInput.tsx
@@ -219,7 +219,7 @@ const TextInput = ({
             onChange(newValue);
           }}
           variant="icon"
-          className="-mr-4"
+          className="pr-0"
         >
           {localValue ?? value ? (
             <MdOutlineCheckBox className="h-6 w-6" />


### PR DESCRIPTION
İki input da zaten w-full, genişlikler eşit. GenericButton'ın iç padding'i — ikon sağ kenara tam oturmuyor. GenericButton icon variant'ı başka yerlerde de kullanılıyor — oradan kaldırsak tüm icon butonların sağ padding'i gider. pr-0 sağ padding'i kaldırıp ikonu kenara yapıştırıyor, her ekranda aynı görünüyor.