### PR TITLE
Ürün Raf Bilgisi'ne konum filtresi ve eksik raf gösterme switch'i eklendi

### DIFF
--- a/src/components/stocks/ProductShelfInfo.tsx
+++ b/src/components/stocks/ProductShelfInfo.tsx
@@ -3,7 +3,7 @@ import { useTranslation } from "react-i18next";
 import { useFilterContext } from "../../context/Filter.context";
 import { useGeneralContext } from "../../context/General.context";
 import { useUserContext } from "../../context/User.context";
-import { ActionEnum, DisabledConditionEnum } from "../../types";
+import { AccountProduct, ActionEnum, DisabledConditionEnum } from "../../types";
 import { useGetAccountExpenseTypes } from "../../utils/api/account/expenseType";
 import {
   useAccountProductMutations,
@@ -32,8 +32,21 @@ const ProductShelfInfo = () => {
     setFilterProductShelfInfoFormElements,
     showProductShelfInfoFilters,
     setShowProductShelfInfoFilters,
+    showProductsWithoutShelf,
+    setShowProductsWithoutShelf,
   } = useFilterContext();
   const { updateAccountProduct } = useAccountProductMutations();
+
+  const selectedLocation = filterProductShelfInfoFormElements?.location;
+  const selectedLocationKey = selectedLocation ? String(selectedLocation) : "";
+
+  const productHasShelfAtLocation = (
+    product: AccountProduct,
+    locationKey: string
+  ) =>
+    (product?.shelfInfo ?? []).some(
+      (si) => String(si.location) === locationKey && !!si.shelf?.trim()
+    );
 
   const productShelfInfoPageDisabledCondition = useMemo(() => {
     return getItem(
@@ -54,7 +67,16 @@ const ProductShelfInfo = () => {
         const matchesProduct =
           filterProductShelfInfoFormElements?.product?.length === 0 ||
           filterProductShelfInfoFormElements?.product?.includes(product._id);
-        return matchesExpense && matchesProduct;
+
+        let matchesLocation = true;
+        if (selectedLocationKey && !showProductsWithoutShelf) {
+          matchesLocation = productHasShelfAtLocation(
+            product,
+            selectedLocationKey
+          );
+        }
+
+        return matchesExpense && matchesProduct && matchesLocation;
       })
       ?.map((product) => {
         const shelfFields = (product.shelfInfo ?? [])?.reduce<
@@ -68,15 +90,24 @@ const ProductShelfInfo = () => {
           ...shelfFields,
         };
       });
-  }, [products, filterProductShelfInfoFormElements]);
+  }, [
+    products,
+    filterProductShelfInfoFormElements,
+    selectedLocationKey,
+    showProductsWithoutShelf,
+  ]);
 
   const columns = useMemo(() => {
     const cols = [
-      { key: t("Name"), isSortable: true, correspondingKey: "name" },
+      { key: t("Product"), isSortable: true, correspondingKey: "name" },
     ];
 
     locations
-      ?.filter((location) => location?.isShelfInfoRequired)
+      ?.filter(
+        (location) =>
+          location?.isShelfInfoRequired &&
+          (!selectedLocationKey || String(location._id) === selectedLocationKey)
+      )
       ?.forEach((location) => {
         cols.push({
           key: location.name,
@@ -86,7 +117,7 @@ const ProductShelfInfo = () => {
       });
 
     return cols;
-  }, [t, locations]);
+  }, [t, locations, selectedLocationKey]);
 
   const rowKeys = useMemo(() => {
     const keys = [
@@ -99,7 +130,11 @@ const ProductShelfInfo = () => {
     ];
 
     locations
-      ?.filter((location) => location?.isShelfInfoRequired)
+      ?.filter(
+        (location) =>
+          location?.isShelfInfoRequired &&
+          (!selectedLocationKey || String(location._id) === selectedLocationKey)
+      )
       ?.forEach((location) => {
         keys.push({
           key: `${location._id}`,
@@ -144,18 +179,45 @@ const ProductShelfInfo = () => {
       });
 
     return keys;
-  }, [locations, isEnableProductShelfEdit, currentPage, updateAccountProduct]);
+  }, [
+    locations,
+    selectedLocationKey,
+    isEnableProductShelfEdit,
+    currentPage,
+    updateAccountProduct,
+  ]);
 
-  const filterPanelInputs = useMemo(
-    () => [
+  const filterPanelInputs = useMemo(() => {
+    const productOptions = (
+      selectedLocationKey && !showProductsWithoutShelf
+        ? products.filter((product) =>
+            productHasShelfAtLocation(product, selectedLocationKey)
+          )
+        : products
+    ).map((product) => ({
+      value: product._id,
+      label: product.name,
+    }));
+
+    return [
+      {
+        type: InputTypes.SELECT,
+        formKey: "location",
+        label: t("Location"),
+        options: locations
+          ?.filter((location) => location?.isShelfInfoRequired)
+          ?.map((location) => ({
+            value: location._id,
+            label: location.name,
+          })),
+        placeholder: t("Location"),
+        required: false,
+      },
       {
         type: InputTypes.SELECT,
         formKey: "product",
         label: t("Product"),
-        options: products.map((product) => ({
-          value: product._id,
-          label: product.name,
-        })),
+        options: productOptions,
         placeholder: t("Product"),
         isMultiple: true,
         required: false,
@@ -172,9 +234,15 @@ const ProductShelfInfo = () => {
         isMultiple: true,
         required: false,
       },
-    ],
-    [products, expenseTypes, t]
-  );
+    ];
+  }, [
+    products,
+    expenseTypes,
+    locations,
+    selectedLocationKey,
+    showProductsWithoutShelf,
+    t,
+  ]);
 
   const filters = useMemo(
     () => [
@@ -208,6 +276,18 @@ const ProductShelfInfo = () => {
           />
         ),
       },
+      {
+        label: t("Show Products Without Shelf Info"),
+        isUpperSide: true,
+        node: (
+          <SwitchButton
+            checked={showProductsWithoutShelf}
+            onChange={() => {
+              setShowProductsWithoutShelf(!showProductsWithoutShelf);
+            }}
+          />
+        ),
+      },
     ],
     [
       t,
@@ -217,6 +297,8 @@ const ProductShelfInfo = () => {
       user,
       isEnableProductShelfEdit,
       setIsEnableProductShelfEdit,
+      showProductsWithoutShelf,
+      setShowProductsWithoutShelf,
     ]
   );
 

--- a/src/context/Filter.context.tsx
+++ b/src/context/Filter.context.tsx
@@ -155,6 +155,8 @@ type FilterContextType = {
   setShowDeletedItems: (state: boolean) => void;
   isEnableProductShelfEdit: boolean;
   setIsEnableProductShelfEdit: (state: boolean) => void;
+  showProductsWithoutShelf: boolean;
+  setShowProductsWithoutShelf: (state: boolean) => void;
   filterProductShelfInfoFormElements: FormElementsState;
   setFilterProductShelfInfoFormElements: (state: FormElementsState) => void;
   showProductShelfInfoFilters: boolean;
@@ -581,6 +583,7 @@ const FilterContext = createContext<FilterContextType>({
   filterProductShelfInfoFormElements: {
     product: [],
     expenseType: [GAMEEXPENSETYPE],
+    location: "",
   },
   setFilterProductShelfInfoFormElements: () => {},
   setFilterAllExpensesPanelFormElements: () => {},
@@ -599,6 +602,8 @@ const FilterContext = createContext<FilterContextType>({
   setShowDeletedItems: () => {},
   isEnableProductShelfEdit: false,
   setIsEnableProductShelfEdit: () => {},
+  showProductsWithoutShelf: false,
+  setShowProductsWithoutShelf: () => {},
   showProductShelfInfoFilters: false,
   setShowProductShelfInfoFilters: () => {},
   showDesertStockFilters: false,
@@ -760,6 +765,8 @@ export const FilterContextProvider = ({ children }: PropsWithChildren) => {
     useState(false);
   const [isEnableProductShelfEdit, setIsEnableProductShelfEdit] =
     useState(false);
+  const [showProductsWithoutShelf, setShowProductsWithoutShelf] =
+    useState(false);
   const [showPersonalSummaryFilters, setShowPersonalSummaryFilters] =
     useState(false);
   const [showServiceInvoiceFilters, setShowServiceInvoiceFilters] =
@@ -813,6 +820,7 @@ export const FilterContextProvider = ({ children }: PropsWithChildren) => {
   ] = useState<FormElementsState>({
     product: [],
     expenseType: [GAMEEXPENSETYPE],
+    location: "",
   });
   const [
     filterAllVisitsPanelFormElements,
@@ -1179,6 +1187,8 @@ export const FilterContextProvider = ({ children }: PropsWithChildren) => {
         setShowDeletedItems: setShowDeletedItems,
         isEnableProductShelfEdit: isEnableProductShelfEdit,
         setIsEnableProductShelfEdit: setIsEnableProductShelfEdit,
+        showProductsWithoutShelf: showProductsWithoutShelf,
+        setShowProductsWithoutShelf: setShowProductsWithoutShelf,
         filterProductShelfInfoFormElements: filterProductShelfInfoFormElements,
         setFilterProductShelfInfoFormElements:
           setFilterProductShelfInfoFormElements,

--- a/src/locales/en/translation.json
+++ b/src/locales/en/translation.json
@@ -195,6 +195,7 @@
   "Add": "Add",
   "Cost": "Cost",
   "Show Filters": "Show Filters",
+  "Show Products Without Shelf Info": "Show Products Without Shelf Info",
   "Filters": "Filters",
   "Vat": "Vat",
   "Note": "Note",

--- a/src/locales/tr/translation.json
+++ b/src/locales/tr/translation.json
@@ -198,6 +198,7 @@
   "Add": "Ekle",
   "Cost": "Maliyet",
   "Show Filters": "Filtreleri Göster",
+  "Show Products Without Shelf Info": "Raf Bilgisi Olmayanları Göster",
   "Filters": "Filtreler",
   "Vat": "Kdv",
   "Note": "Not",


### PR DESCRIPTION


- Filtre paneline tek seçimli konum filtresi eklendi; konum seçilince

  tablo yalnızca "Ürün" ve o konumun kolonunu gösteriyor

- Konum seçiliyken sadece o konumda dolu rafı olan ürünler listeleniyor

- "Raf Bilgisi Olmayanları Göster" switch'i eklendi; açıkken o konumda

  rafı olmayan ürünler de tabloya geliyor (raf atayabilmek için)

- İlk kolon başlığı "Ad" yerine "Ürün" yapıldı