### PR TITLE
feat: sidebar arama çubuğu için klavye kısayolu eklendi (Cmd/Ctrl+Shift+F)

### DIFF
--- a/src/components/common/Sidebar.tsx
+++ b/src/components/common/Sidebar.tsx
@@ -1,5 +1,7 @@
 import { useEffect, useRef } from "react";
 import { useTranslation } from "react-i18next";
+import type { AutocompleteInputHandle } from "../panelComponents/FormElements/AutocompleteInput";
+import { useHotkey } from "../../hooks/useHotkey";
 import {
   FiChevronDown,
   FiChevronLeft,
@@ -35,6 +37,8 @@ export const Sidebar = () => {
   const isExpanded = isSidebarOpen || isHoverExpanded;
   const hoverTimeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null);
   const previousRouteRef = useRef<string | null>(null);
+  const searchInputRef = useRef<AutocompleteInputHandle>(null);
+  const isFirstRender = useRef(true);
 
   const {
     user,
@@ -53,6 +57,14 @@ export const Sidebar = () => {
     setSearchValue,
     handleLogoutClick,
   } = useSidebarNavigation(() => setIsSidebarOpen(false));
+
+  useHotkey("meta+shift+f, ctrl+shift+f", () => {
+    if (!isSidebarOpen) {
+      setIsSidebarOpen(true);
+    } else {
+      searchInputRef.current?.focus();
+    }
+  });
 
   const handleMouseEnter = () => {
     if (isSidebarOpen) return;
@@ -140,7 +152,17 @@ export const Sidebar = () => {
   };
 
   useEffect(() => {
-    if (!isSidebarOpen) {
+    if (isFirstRender.current) {
+      isFirstRender.current = false;
+      if (!isSidebarOpen) {
+        setOpenGroups({});
+      }
+      return;
+    }
+
+    if (isSidebarOpen) {
+      searchInputRef.current?.focus();
+    } else {
       setOpenGroups({});
     }
   }, [isSidebarOpen]);
@@ -246,6 +268,7 @@ export const Sidebar = () => {
           <div className="mb-4">
             {isExpanded ? (
               <AutocompleteInput
+                ref={searchInputRef}
                 placeholder={t("Search menu...") || "Search menu..."}
                 value={searchValue}
                 options={menuOptions}

--- a/src/components/panelComponents/FormElements/AutocompleteInput.tsx
+++ b/src/components/panelComponents/FormElements/AutocompleteInput.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useRef, useState } from "react";
+import { forwardRef, useEffect, useImperativeHandle, useRef, useState } from "react";
 import { IoIosClose } from "react-icons/io";
 import { MdArrowDropDown, MdOutlineDone } from "react-icons/md";
 import { GenericButton } from "../../common/GenericButton";
@@ -40,7 +40,11 @@ const getOptionValue = (option: string | { value: string; label?: string }) =>
 const getOptionLabel = (option: string | { value: string; label?: string }) =>
   typeof option === "string" ? option : option.label ?? option.value;
 
-const AutocompleteInput = ({
+export type AutocompleteInputHandle = {
+  focus: () => void;
+};
+
+const AutocompleteInput = forwardRef<AutocompleteInputHandle, AutocompleteInputProps>(({
   label,
   placeholder,
   value,
@@ -56,7 +60,7 @@ const AutocompleteInput = ({
   isSortDisabled = false,
   className = "px-4 py-2.5 border border-gray-300 rounded-md",
   clearOnFocus = false,
-}: AutocompleteInputProps) => {
+}: AutocompleteInputProps, ref) => {
   const [isOpen, setIsOpen] = useState(false);
   const [activeIndex, setActiveIndex] = useState(-1);
   const [filteredOptions, setFilteredOptions] = useState<
@@ -64,6 +68,11 @@ const AutocompleteInput = ({
   >([]);
   const [searchInput, setSearchInput] = useState(value);
   const inputRef = useRef<HTMLInputElement>(null);
+
+  useImperativeHandle(ref, () => ({
+    focus: () => inputRef.current?.focus(),
+  }));
+
   const containerRef = useRef<HTMLDivElement>(null);
   const listboxIdRef = useRef(
     `autocomplete-listbox-${Math.random().toString(36).slice(2, 10)}`
@@ -306,6 +315,8 @@ const AutocompleteInput = ({
       </div>
     </div>
   );
-};
+});
+
+AutocompleteInput.displayName = "AutocompleteInput";
 
 export default AutocompleteInput;

--- a/src/hooks/useHotkey.ts
+++ b/src/hooks/useHotkey.ts
@@ -1,0 +1,62 @@
+import { useEffect, useMemo, useRef } from "react";
+
+type HotkeyCombo = {
+  key: string;
+  meta?: boolean;
+  ctrl?: boolean;
+  shift?: boolean;
+  alt?: boolean;
+};
+
+function parseCombo(combo: string): HotkeyCombo {
+  const parts = combo.toLowerCase().replace(/\s+/g, "").split("+");
+  return {
+    key: parts[parts.length - 1],
+    meta: parts.includes("meta") || parts.includes("cmd"),
+    ctrl: parts.includes("ctrl"),
+    shift: parts.includes("shift"),
+    alt: parts.includes("alt"),
+  };
+}
+
+function matchesCombo(e: KeyboardEvent, combo: HotkeyCombo): boolean {
+  return (
+    e.key.toLowerCase() === combo.key &&
+    !!e.metaKey === !!combo.meta &&
+    !!e.ctrlKey === !!combo.ctrl &&
+    !!e.shiftKey === !!combo.shift &&
+    !!e.altKey === !!combo.alt
+  );
+}
+
+export function useHotkey(combo: string, callback: () => void) {
+  const callbackRef = useRef(callback);
+  callbackRef.current = callback;
+
+  const combos = useMemo(
+    () => combo.split(",").map((c) => parseCombo(c.trim())),
+    [combo]
+  );
+
+  useEffect(() => {
+    const handler = (e: KeyboardEvent) => {
+      const target = e.target as HTMLElement;
+      if (
+        target &&
+        (target.tagName === "INPUT" ||
+          target.tagName === "TEXTAREA" ||
+          target.isContentEditable)
+      ) {
+        return;
+      }
+
+      if (combos.some((c) => matchesCombo(e, c))) {
+        e.preventDefault();
+        callbackRef.current();
+      }
+    };
+
+    document.addEventListener("keydown", handler);
+    return () => document.removeEventListener("keydown", handler);
+  }, [combos]);
+}


### PR DESCRIPTION
- Stale closure olmadan çalışan generic useHotkey hook'u oluşturuldu
- AutocompleteInput'a dışarıdan focus() çağırabilmek için forwardRef eklendi
- Sidebar'a meta+shift+f / ctrl+shift+f kısayolu bağlandı