### PR TITLE
(henüz tamamlanmadı)fix: İade işlemlerindeki hatalı hesaplama ve senkronizasyon sorunlarının düzeltilmesi

### DIFF
--- a/src/components/orders/orderPayment/OrderPaymentModal.tsx
+++ b/src/components/orders/orderPayment/OrderPaymentModal.tsx
@@ -229,7 +229,10 @@ const OrderPaymentModal = ({
             (collection) => (collection?.table as Table)?._id === tableId
           )
           ?.reduce((acc, collection) => {
-            if (collection?.status === OrderCollectionStatus.CANCELLED) {
+            if (
+              collection?.status === OrderCollectionStatus.CANCELLED ||
+              collection?.status === OrderCollectionStatus.RETURNED
+            ) {
               return acc;
             }
             return acc + (collection?.amount ?? 0);
@@ -263,7 +266,10 @@ const OrderPaymentModal = ({
               collection?.activityPlayer === selectedActivityUser)
         )
         ?.reduce((acc, collection) => {
-          if (collection?.status === OrderCollectionStatus.CANCELLED) {
+          if (
+            collection?.status === OrderCollectionStatus.CANCELLED ||
+            collection?.status === OrderCollectionStatus.RETURNED
+          ) {
             return acc;
           }
           return acc + (collection?.amount ?? 0);
@@ -327,7 +333,7 @@ const OrderPaymentModal = ({
     [tableOrders, collectionsTotalAmount, totalAmount, discountAmount]
   );
   const refundAmount = Math.max(
-    totalMoneySpend - (totalAmount - discountAmount),
+    totalMoneySpend - (displayedTotalAmount - discountAmount),
     allTotalMoneySpend - (allTotalAmount - allDiscountAmount)
   );
 
@@ -340,9 +346,12 @@ const OrderPaymentModal = ({
       return Math.max(0, totalAmount - discountAmount - collectionsTotalAmount);
     }
     // For normal case (no specific user): minimum of filtered orders and all orders
-    return Math.min(
-      totalAmount - discountAmount - collectionsTotalAmount,
-      allTotalAmount - allDiscountAmount - allCollectionsTotalAmount
+    return Math.max(
+      0,
+      Math.min(
+        totalAmount - discountAmount - collectionsTotalAmount,
+        allTotalAmount - allDiscountAmount - allCollectionsTotalAmount
+      )
     );
   }, [
     selectedActivityUser,

--- a/src/components/orders/orderPayment/OrderPaymentModal.tsx
+++ b/src/components/orders/orderPayment/OrderPaymentModal.tsx
@@ -306,6 +306,15 @@ const OrderPaymentModal = ({
   );
   const totalAmount = useMemo(
     () =>
+      tableOrders
+        ?.filter((order) => order?.status !== OrderStatus.RETURNED)
+        ?.reduce((acc, order) => {
+          return acc + order?.unitPrice * order?.quantity;
+        }, 0),
+    [tableOrders]
+  );
+  const displayedTotalAmount = useMemo(
+    () =>
       tableOrders?.reduce((acc, order) => {
         return acc + order?.unitPrice * order?.quantity;
       }, 0),
@@ -1219,7 +1228,7 @@ const OrderPaymentModal = ({
                   tableOrders={tableOrders}
                   collectionsTotalAmount={collectionsTotalAmount}
                   tables={tables}
-                  totalAmount={totalAmount}
+                  totalAmount={displayedTotalAmount}
                   discountAmount={discountAmount}
                   unpaidAmount={unpaidAmount}
                 />

--- a/src/components/orders/orderPayment/OrderPaymentModal.tsx
+++ b/src/components/orders/orderPayment/OrderPaymentModal.tsx
@@ -312,16 +312,16 @@ const OrderPaymentModal = ({
   );
   const totalAmount = useMemo(
     () =>
-      tableOrders
-        ?.filter((order) => order?.status !== OrderStatus.RETURNED)
-        ?.reduce((acc, order) => {
+      (tableOrders ?? [])
+        .filter((order) => order?.status !== OrderStatus.RETURNED)
+        .reduce((acc, order) => {
           return acc + order?.unitPrice * order?.quantity;
         }, 0),
     [tableOrders]
   );
   const displayedTotalAmount = useMemo(
     () =>
-      tableOrders?.reduce((acc, order) => {
+      (tableOrders ?? []).reduce((acc, order) => {
         return acc + order?.unitPrice * order?.quantity;
       }, 0),
     [tableOrders]

--- a/src/components/orders/orderPayment/orderList/OrderLists.tsx
+++ b/src/components/orders/orderPayment/orderList/OrderLists.tsx
@@ -1,7 +1,7 @@
 import { useTranslation } from "react-i18next";
 import { toast } from "react-toastify";
 import { useOrderContext } from "../../../../context/Order.context";
-import { Order, Table } from "../../../../types";
+import { Order, OrderStatus, Table } from "../../../../types";
 import {
   useCreateOrderForDiscountMutation,
   useCreateOrderForDivideMutation,
@@ -259,7 +259,9 @@ const OrderLists = ({
           <DiscountScreen table={table} />
         ) : (
           <UnpaidOrders
-            tableOrders={tableOrders}
+            tableOrders={tableOrders?.filter(
+              (order) => order?.status !== OrderStatus.RETURNED
+            )}
             collectionsTotalAmount={collectionsTotalAmount}
           />
         ))}

--- a/src/components/orders/orderPayment/orderList/PaidOrders.tsx
+++ b/src/components/orders/orderPayment/orderList/PaidOrders.tsx
@@ -1,4 +1,5 @@
 import { Tooltip } from "@material-tailwind/react";
+import { useTranslation } from "react-i18next";
 import { HiOutlineTrash } from "react-icons/hi2";
 import { MdOutlineOnlinePrediction } from "react-icons/md";
 import { useDataContext } from "../../../../context/Data.context";
@@ -13,6 +14,7 @@ type Props = {
   tableOrders: Order[];
 };
 const PaidOrders = ({ tableOrders }: Props) => {
+  const { t } = useTranslation();
   const discounts = useGetOrderDiscounts()?.filter(
     (discount) => discount?.status !== OrderDiscountStatus.DELETED
   );
@@ -68,6 +70,9 @@ const PaidOrders = ({ tableOrders }: Props) => {
                   {")"}-
                 </p>
                 <p>{getItem(order?.item, items)?.name}</p>
+                {order.status === OrderStatus.RETURNED && (
+                  <span className="text-xs self-center">({t("Returned")})</span>
+                )}
                 {order?.isOnlinePrice && (
                   <Tooltip
                     content={"online"}

--- a/src/hooks/useWebSocket.ts
+++ b/src/hooks/useWebSocket.ts
@@ -382,9 +382,13 @@ export function useWebSocket(shouldConnect = false) {
                 continue;
               }
             }
-            oldData = oldData.map((order) =>
-              order._id === normalizedOrder._id ? normalizedOrder : order
-            );
+            if (oldData.find((o) => o._id === normalizedOrder._id)) {
+              oldData = oldData.map((order) =>
+                order._id === normalizedOrder._id ? normalizedOrder : order
+              );
+            } else {
+              oldData = [...oldData, normalizedOrder];
+            }
           }
           return oldData;
         }

--- a/src/hooks/useWebSocket.ts
+++ b/src/hooks/useWebSocket.ts
@@ -382,13 +382,15 @@ export function useWebSocket(shouldConnect = false) {
                 continue;
               }
             }
-            if (oldData.find((o) => o._id === normalizedOrder._id)) {
-              oldData = oldData.map((order) =>
-                order._id === normalizedOrder._id ? normalizedOrder : order
-              );
-            } else {
-              oldData = [...oldData, normalizedOrder];
-            }
+            let found = false;
+            const updatedData = oldData.map((order) => {
+              if (order._id === normalizedOrder._id) {
+                found = true;
+                return normalizedOrder;
+              }
+              return order;
+            });
+            oldData = found ? updatedData : [...oldData, normalizedOrder];
           }
           return oldData;
         }


### PR DESCRIPTION
- İade edilen siparişler ödenmemiş siparişler listesinden (`UnpaidOrders`) hariç tutuldu
- Ödenen siparişler listesinde (`PaidOrders`) iade edilmiş siparişlerin yanına "İade" rozeti eklendi                                                                                                                                        - `RETURNED` durumdaki tahsilatlar `collectionsTotalAmount` hesaplarından hariç tutuldu; bu sayede iade sonrası aynı masaya yeni sipariş girildiğinde "Kalan" alanı doğru güncelleniyor
- "Kalan" tutarının (`unpaidAmount`) negatife düşmesi engellendi
- Para üstü (`refundAmount`) hesabında iade edilen siparişlerin tutarı dahil edilerek hatalı para üstü gösteriminin önüne geçildi
- "Toplam" alanı iade edilen siparişler de dahil edilerek gösterildi
- WebSocket üzerinden gelen yeni siparişlerin (kısmi iade split'i sonrası oluşan) mevcut listede yoksa eklenmesi sağlandı