### PR TITLE
(2/2) Çalışma Saatleri (Takvim) sayfasında geniş çaplı geliştirmeler (önce aşağıdaki 1/2'yi alıp sonra bunu alırsak daha iyi olur)

### DIFF
--- a/src/components/calendar/MonthlyBody.tsx
+++ b/src/components/calendar/MonthlyBody.tsx
@@ -1,5 +1,5 @@
 import { addDays, format, getDay, isSameDay, Locale, parseISO, subDays } from "date-fns";
-import { createContext, ReactNode, useContext } from "react";
+import { createContext, ReactNode, useContext, useMemo } from "react";
 import { useTranslation } from "react-i18next";
 import { H5 } from "../panelComponents/Typography";
 import { useMonthlyCalendar } from "./MonthlyCalendar";
@@ -103,6 +103,14 @@ export function MonthlyBody<DayData>({
         addDays(daysToRender[daysToRender.length - 1], index + 1)
       )
     : [];
+  const parsedEvents = useMemo(
+    () => events.map((event) => ({ event, parsedDate: parseISO(event.date) })),
+    [events]
+  );
+  const eventsForDay = (day: Date) =>
+    parsedEvents
+      .filter(({ parsedDate }) => isSameDay(parsedDate, day))
+      .map(({ event }) => event);
   return (
     <div className="bg-white border-l-2 border-t-2 rounded-lg mb-6">
       <div
@@ -126,9 +134,7 @@ export function MonthlyBody<DayData>({
                 value={{
                   day,
                   isOutsideMonth: true,
-                  events: events.filter((data) =>
-                    isSameDay(parseISO(data.date), day)
-                  ),
+                  events: eventsForDay(day),
                 }}
               >
                 {children}
@@ -146,9 +152,7 @@ export function MonthlyBody<DayData>({
             key={day.toISOString()}
             value={{
               day,
-              events: events.filter((data) =>
-                isSameDay(parseISO(data.date), day)
-              ),
+              events: eventsForDay(day),
             }}
           >
             {children}
@@ -160,9 +164,7 @@ export function MonthlyBody<DayData>({
             value={{
               day,
               isOutsideMonth: true,
-              events: events.filter((data) =>
-                isSameDay(parseISO(data.date), day)
-              ),
+              events: eventsForDay(day),
             }}
           >
             {children}

--- a/src/components/calendar/MonthlyBody.tsx
+++ b/src/components/calendar/MonthlyBody.tsx
@@ -1,4 +1,4 @@
-import { format, getDay, isSameDay, Locale, parseISO } from "date-fns";
+import { addDays, format, getDay, isSameDay, Locale, parseISO, subDays } from "date-fns";
 import { createContext, ReactNode, useContext } from "react";
 import { useTranslation } from "react-i18next";
 import { H5 } from "../panelComponents/Typography";
@@ -10,6 +10,7 @@ const MonthlyBodyContext = createContext({} as any);
 type BodyState<DayData> = {
   day: Date;
   events: DayData[];
+  isOutsideMonth?: boolean;
 };
 
 export function useMonthlyBody<DayData>() {
@@ -69,12 +70,20 @@ type MonthlyBodyProps<DayData> = {
   omitDays?: number[];
   events: (DayData & { date: string })[];
   children: ReactNode;
+  /*
+    when true, the empty cells before the first day and after the last day
+    of the month are replaced with the adjacent days of the previous/next
+    month (shaded), instead of being left blank. the caller is responsible
+    for fetching events that cover this leading/trailing range as well.
+  */
+  showOverflowDays?: boolean;
 };
 
 export function MonthlyBody<DayData>({
   omitDays,
   events,
   children,
+  showOverflowDays,
 }: MonthlyBodyProps<DayData>) {
   const { days, locale } = useMonthlyCalendar();
   const { t } = useTranslation();
@@ -85,6 +94,15 @@ export function MonthlyBody<DayData>({
     locale,
   });
   const headingClassName = "border-b-2 p-2 border-r-2 lg:block hidden";
+  const overflowDays = showOverflowDays
+    ? padding.map((_, index) => subDays(daysToRender[0], padding.length - index))
+    : [];
+  const lastDayIndex = (getDay(daysToRender[daysToRender.length - 1]) + 6) % 7; // Monday=0..Sunday=6
+  const trailingOverflowDays = showOverflowDays
+    ? Array.from({ length: 6 - lastDayIndex }, (_, index) =>
+        addDays(daysToRender[daysToRender.length - 1], index + 1)
+      )
+    : [];
   return (
     <div className="bg-white border-l-2 border-t-2 rounded-lg mb-6">
       <div
@@ -101,18 +119,47 @@ export function MonthlyBody<DayData>({
             <H5>{t(day.label)}</H5>
           </div>
         ))}
-        {padding.map((_, index) => (
-          <div
-            key={index}
-            className={headingClassName}
-            aria-label="Empty Day"
-          />
-        ))}
+        {overflowDays.length > 0
+          ? overflowDays.map((day) => (
+              <MonthlyBodyContext.Provider
+                key={day.toISOString()}
+                value={{
+                  day,
+                  isOutsideMonth: true,
+                  events: events.filter((data) =>
+                    isSameDay(parseISO(data.date), day)
+                  ),
+                }}
+              >
+                {children}
+              </MonthlyBodyContext.Provider>
+            ))
+          : padding.map((_, index) => (
+              <div
+                key={index}
+                className={headingClassName}
+                aria-label="Empty Day"
+              />
+            ))}
         {daysToRender.map((day) => (
           <MonthlyBodyContext.Provider
             key={day.toISOString()}
             value={{
               day,
+              events: events.filter((data) =>
+                isSameDay(parseISO(data.date), day)
+              ),
+            }}
+          >
+            {children}
+          </MonthlyBodyContext.Provider>
+        ))}
+        {trailingOverflowDays.map((day) => (
+          <MonthlyBodyContext.Provider
+            key={day.toISOString()}
+            value={{
+              day,
+              isOutsideMonth: true,
               events: events.filter((data) =>
                 isSameDay(parseISO(data.date), day)
               ),
@@ -131,16 +178,20 @@ type MonthlyDayProps<DayData> = {
 };
 export function MonthlyDay<DayData>({ renderDay }: MonthlyDayProps<DayData>) {
   const { locale } = useMonthlyCalendar();
-  const { day, events } = useMonthlyBody<DayData>();
+  const { day, events, isOutsideMonth } = useMonthlyBody<DayData>();
   const dayNumber = format(day, "d", { locale });
 
   return (
     <div
       aria-label={`Events for day ${dayNumber}`}
-      className="h-48 p-2 border-b-2 border-r-2"
+      className={`h-48 p-2 border-b-2 border-r-2 ${
+        isOutsideMonth ? "bg-gray-100 opacity-60" : ""
+      }`}
     >
       <div className="flex justify-between">
-        <div className="font-bold">{dayNumber}</div>
+        <div className={`font-bold ${isOutsideMonth ? "text-gray-400" : ""}`}>
+          {dayNumber}
+        </div>
         <div className="lg:hidden block">{format(day, "EEEE", { locale })}</div>
       </div>
       <ul className="overflow-hidden max-h-36 overflow-y-auto">

--- a/src/components/calendar/MonthlyBody.tsx
+++ b/src/components/calendar/MonthlyBody.tsx
@@ -40,7 +40,7 @@ export const handleOmittedDays = ({
   }
 
   // hariç tutulan bir gün ayın başlangıcından önceyse dolguyu (padding) hariç tut
-  let firstDayOfMonth = getDay(daysToRender[0]) as number;
+  let firstDayOfMonth = daysToRender[0] ? (getDay(daysToRender[0]) as number) : 0;
   firstDayOfMonth = (firstDayOfMonth + 6) % 7;
   if (omitDays) {
     const subtractOmittedDays = omitDays.filter(
@@ -94,15 +94,19 @@ export function MonthlyBody<DayData>({
     locale,
   });
   const headingClassName = "border-b-2 p-2 border-r-2 lg:block hidden";
-  const overflowDays = showOverflowDays
-    ? padding.map((_, index) => subDays(daysToRender[0], padding.length - index))
-    : [];
-  const lastDayIndex = (getDay(daysToRender[daysToRender.length - 1]) + 6) % 7; // Pazartesi=0..Pazar=6
-  const trailingOverflowDays = showOverflowDays
-    ? Array.from({ length: 6 - lastDayIndex }, (_, index) =>
-        addDays(daysToRender[daysToRender.length - 1], index + 1)
-      )
-    : [];
+  const firstDay = daysToRender[0];
+  const lastDay = daysToRender[daysToRender.length - 1];
+  const overflowDays =
+    showOverflowDays && firstDay
+      ? padding.map((_, index) => subDays(firstDay, padding.length - index))
+      : [];
+  const lastDayIndex = lastDay ? (getDay(lastDay) + 6) % 7 : 0; // Pazartesi=0..Pazar=6
+  const trailingOverflowDays =
+    showOverflowDays && lastDay
+      ? Array.from({ length: 6 - lastDayIndex }, (_, index) =>
+          addDays(lastDay, index + 1)
+        )
+      : [];
   const parsedEvents = useMemo(
     () => events.map((event) => ({ event, parsedDate: parseISO(event.date) })),
     [events]

--- a/src/components/calendar/MonthlyBody.tsx
+++ b/src/components/calendar/MonthlyBody.tsx
@@ -31,7 +31,7 @@ export const handleOmittedDays = ({
   let headings = daysInWeek({ locale });
   let daysToRender = days;
 
-  //omit the headings and days of the week that were passed in
+  //parametre olarak geçilen gün başlıklarını ve günleri hariç tut
   if (omitDays) {
     headings = daysInWeek({ locale }).filter(
       (day) => !omitDays.includes(day.day)
@@ -39,7 +39,7 @@ export const handleOmittedDays = ({
     daysToRender = days.filter((day) => !omitDays.includes(getDay(day)));
   }
 
-  // omit the padding if an omitted day was before the start of the month
+  // hariç tutulan bir gün ayın başlangıcından önceyse dolguyu (padding) hariç tut
   let firstDayOfMonth = getDay(daysToRender[0]) as number;
   firstDayOfMonth = (firstDayOfMonth + 6) % 7;
   if (omitDays) {
@@ -53,7 +53,7 @@ export const handleOmittedDays = ({
   return { headings, daysToRender, padding };
 };
 
-//to prevent these from being purged in production, we make a lookup object
+//production'da bu class'ların silinmesini (purge) önlemek için bir lookup objesi oluşturuyoruz
 const headingClasses: { [key: string]: string } = {
   l3: "lg:grid-cols-3",
   l4: "lg:grid-cols-4",
@@ -64,17 +64,17 @@ const headingClasses: { [key: string]: string } = {
 
 type MonthlyBodyProps<DayData> = {
   /*
-    skip days, an array of days, starts at sunday (0), saturday is 6
-    ex: [0,6] would remove sunday and saturday from rendering
+    atlanacak günler, bir gün dizisi, pazar (0) ile başlar, cumartesi 6'dır
+    örn: [0,6] pazar ve cumartesiyi görüntülemeden kaldırır
   */
   omitDays?: number[];
   events: (DayData & { date: string })[];
   children: ReactNode;
   /*
-    when true, the empty cells before the first day and after the last day
-    of the month are replaced with the adjacent days of the previous/next
-    month (shaded), instead of being left blank. the caller is responsible
-    for fetching events that cover this leading/trailing range as well.
+    true olduğunda, ayın ilk gününden önceki ve son gününden sonraki boş
+    hücreler, boş bırakılmak yerine önceki/sonraki ayın günleriyle
+    (gölgeli olarak) doldurulur. bu baştaki/sondaki aralığı kapsayan
+    event'leri getirmek çağıran tarafın sorumluluğundadır.
   */
   showOverflowDays?: boolean;
 };
@@ -97,7 +97,7 @@ export function MonthlyBody<DayData>({
   const overflowDays = showOverflowDays
     ? padding.map((_, index) => subDays(daysToRender[0], padding.length - index))
     : [];
-  const lastDayIndex = (getDay(daysToRender[daysToRender.length - 1]) + 6) % 7; // Monday=0..Sunday=6
+  const lastDayIndex = (getDay(daysToRender[daysToRender.length - 1]) + 6) % 7; // Pazartesi=0..Pazar=6
   const trailingOverflowDays = showOverflowDays
     ? Array.from({ length: 6 - lastDayIndex }, (_, index) =>
         addDays(daysToRender[daysToRender.length - 1], index + 1)
@@ -176,9 +176,25 @@ export function MonthlyBody<DayData>({
 }
 
 type MonthlyDayProps<DayData> = {
-  renderDay: (events: DayData[]) => ReactNode;
+  renderDay: (events: DayData[], day: Date) => ReactNode;
+  /*
+    renderDay çıktısını saran <ul>'un varsayılan className'ini geçersiz kılar.
+    günün öğelerini varsayılan tek sütunlu dizilim yerine bir grid içinde
+    (örn. mobilde 2 sütun) göstermek için kullanışlıdır.
+  */
+  listClassName?: string;
+  /*
+    çağıranın tek tek gün hücrelerini renklendirmesini sağlar (örn. geçmiş
+    günler, bugün). hücrenin tarihini ve komşu aya ait taşan bir gün olup
+    olmadığını alır; varsayılan stili değiştirmemek için "" döndürün.
+  */
+  dayClassName?: (day: Date, isOutsideMonth: boolean) => string;
 };
-export function MonthlyDay<DayData>({ renderDay }: MonthlyDayProps<DayData>) {
+export function MonthlyDay<DayData>({
+  renderDay,
+  listClassName,
+  dayClassName,
+}: MonthlyDayProps<DayData>) {
   const { locale } = useMonthlyCalendar();
   const { day, events, isOutsideMonth } = useMonthlyBody<DayData>();
   const dayNumber = format(day, "d", { locale });
@@ -187,17 +203,25 @@ export function MonthlyDay<DayData>({ renderDay }: MonthlyDayProps<DayData>) {
     <div
       aria-label={`Events for day ${dayNumber}`}
       className={`h-48 p-2 border-b-2 border-r-2 ${
-        isOutsideMonth ? "bg-gray-100 opacity-60" : ""
+        isOutsideMonth
+          ? "bg-gray-100 opacity-60"
+          : dayClassName?.(day, !!isOutsideMonth) ?? ""
       }`}
     >
-      <div className="flex justify-between">
-        <div className={`font-bold ${isOutsideMonth ? "text-gray-400" : ""}`}>
+      <div className="flex justify-between leading-none">
+        <div
+          className={`font-bold leading-none ${
+            isOutsideMonth ? "text-gray-400" : ""
+          }`}
+        >
           {dayNumber}
         </div>
-        <div className="lg:hidden block">{format(day, "EEEE", { locale })}</div>
+        <div className="lg:hidden block leading-none">
+          {format(day, "EEEE", { locale })}
+        </div>
       </div>
-      <ul className="overflow-hidden max-h-36 overflow-y-auto">
-        {renderDay(events)}
+      <ul className={listClassName ?? "overflow-hidden max-h-36 overflow-y-auto"}>
+        {renderDay(events, day)}
       </ul>
     </div>
   );

--- a/src/components/panelComponents/FormElements/GenericAddEditPanel.tsx
+++ b/src/components/panelComponents/FormElements/GenericAddEditPanel.tsx
@@ -79,6 +79,13 @@ type Props<T> = {
   upperMessageColumns?: 1 | 2;
   additionalButtons?: AdditionalButtonProps[];
   stickyFooterButtons?: boolean;
+  /*
+    centers the modal vertically on mobile too (default: aligned to the top
+    on mobile, centered from sm upward). only use for short panels that are
+    guaranteed to fit within the viewport, since centering a panel taller
+    than the screen can push its top content out of scroll reach on mobile.
+  */
+  centerOnMobile?: boolean;
   itemToEdit?: {
     id: number | string;
     updates: T;
@@ -133,6 +140,7 @@ const GenericAddEditPanel = <T,>({
   submitItem,
   nonImageInputsClassName,
   stickyFooterButtons = false,
+  centerOnMobile = false,
 }: Props<T>) => {
   const { t } = useTranslation();
   const [allRequiredFilled, setAllRequiredFilled] = useState(false);
@@ -1091,7 +1099,9 @@ const GenericAddEditPanel = <T,>({
   };
   return (
     <div
-      className={`__className_a182b8 fixed inset-0 flex items-center justify-center overflow-y-auto bg-gray-800 bg-opacity-50 z-50 ${
+      className={`__className_a182b8 fixed inset-0 flex ${
+        centerOnMobile ? "items-center" : "items-start sm:items-center"
+      } justify-center overflow-y-auto bg-gray-800 bg-opacity-50 z-50 ${
         !isOpen && "hidden"
       }`}
     >

--- a/src/components/panelComponents/FormElements/GenericAddEditPanel.tsx
+++ b/src/components/panelComponents/FormElements/GenericAddEditPanel.tsx
@@ -1091,7 +1091,7 @@ const GenericAddEditPanel = <T,>({
   };
   return (
     <div
-      className={`__className_a182b8 fixed inset-0 flex items-start sm:items-center justify-center overflow-y-auto bg-gray-800 bg-opacity-50 z-50 ${
+      className={`__className_a182b8 fixed inset-0 flex items-center justify-center overflow-y-auto bg-gray-800 bg-opacity-50 z-50 ${
         !isOpen && "hidden"
       }`}
     >

--- a/src/components/visits/ShiftsCalendar.tsx
+++ b/src/components/visits/ShiftsCalendar.tsx
@@ -1,4 +1,4 @@
-import { endOfMonth, format, startOfMonth } from "date-fns";
+import { endOfMonth, endOfWeek, format, startOfMonth, startOfWeek } from "date-fns";
 import { useState } from "react";
 import { useTranslation } from "react-i18next";
 import { useLocationContext } from "../../context/Location.context";
@@ -27,8 +27,16 @@ export default function ShiftsCalendar() {
   const locations = useGetStoreLocations();
   const users = useGetUsersMinimal();
 
-  const after = format(currentMonth, "yyyy-MM-dd");
-  const before = format(endOfMonth(currentMonth), "yyyy-MM-dd");
+  // include the leading/trailing days of the adjacent months that show up
+  // as shaded overflow cells on the calendar grid (week starts on Monday)
+  const after = format(
+    startOfWeek(currentMonth, { weekStartsOn: 1 }),
+    "yyyy-MM-dd"
+  );
+  const before = format(
+    endOfWeek(endOfMonth(currentMonth), { weekStartsOn: 1 }),
+    "yyyy-MM-dd"
+  );
 
   const shifts = useGetShifts(after, before, selectedLocationId);
 
@@ -63,7 +71,7 @@ export default function ShiftsCalendar() {
         onCurrentMonthChange={(date) => setCurrentMonth(date)}
       >
         <MonthlyNav />
-        <MonthlyBody<ShiftCalendarEvent> events={events}>
+        <MonthlyBody<ShiftCalendarEvent> events={events} showOverflowDays>
           <MonthlyDay<ShiftCalendarEvent>
             renderDay={(dayShifts) => {
               if (!dayShifts.length) return null;

--- a/src/components/visits/ShiftsCalendar.tsx
+++ b/src/components/visits/ShiftsCalendar.tsx
@@ -20,7 +20,7 @@ import { ActionEnum, DisabledConditionEnum, Shift, ShiftValue } from "../../type
 import { useGetStoreLocations } from "../../utils/api/location";
 import { useGetDisabledConditions } from "../../utils/api/panelControl/disabledCondition";
 import { useGetShifts, useShiftMutations } from "../../utils/api/shift";
-import { useGetUsersMinimal } from "../../utils/api/user";
+import { useGetAllUserRoles, useGetUsersMinimal } from "../../utils/api/user";
 import { convertDateFormat } from "../../utils/format";
 import { getItem } from "../../utils/getItem";
 import { MonthlyBody, MonthlyDay } from "../calendar/MonthlyBody";
@@ -28,6 +28,7 @@ import { MonthlyCalendar, MonthlyNav } from "../calendar/MonthlyCalendar";
 import GenericAddEditPanel from "../panelComponents/FormElements/GenericAddEditPanel";
 import ButtonFilter from "../panelComponents/common/ButtonFilter";
 import SwitchButton from "../panelComponents/common/SwitchButton";
+import FilterPanel from "../panelComponents/Tables/FilterPanel";
 import { FormKeyTypeEnum, InputTypes } from "../panelComponents/shared/types";
 
 type ShiftCalendarEvent = Shift & { date: string };
@@ -46,6 +47,7 @@ export default function ShiftsCalendar() {
   );
   const locations = useGetStoreLocations();
   const users = useGetUsersMinimal();
+  const roles = useGetAllUserRoles();
   const { user } = useUserContext();
   const disabledConditions = useGetDisabledConditions();
   const shiftsDisabledCondition = getItem(
@@ -91,6 +93,55 @@ export default function ShiftsCalendar() {
   const [assignForm, setAssignForm] = useState<{ selectedUsers: string[] }>({
     selectedUsers: [],
   });
+
+  const [showFilters, setShowFilters] = useState(false);
+  const [filterPanelFormElements, setFilterPanelFormElements] = useState<{
+    role: number[];
+    user: string;
+  }>({ role: [], user: "" });
+  const filterPanelInputs = [
+    {
+      type: InputTypes.SELECT,
+      formKey: "role",
+      label: t("Roles"),
+      options: roles?.map((role) => ({ value: role._id, label: role.name })),
+      isMultiple: true,
+      placeholder: t("Roles"),
+      required: false,
+    },
+    {
+      type: InputTypes.SELECT,
+      formKey: "user",
+      label: t("User"),
+      options: users
+        ?.filter((u) => {
+          if (filterPanelFormElements?.role?.length > 0) {
+            return filterPanelFormElements.role.includes(u?.role?._id);
+          }
+          return true;
+        })
+        ?.map((u) => ({ value: u._id, label: u.name })),
+      placeholder: t("User"),
+      required: false,
+    },
+  ];
+  const matchesShiftFilters = (userId: string) => {
+    const foundUser = getItem(userId, users);
+    if (!foundUser) return false;
+    if (
+      filterPanelFormElements?.role?.length > 0 &&
+      !filterPanelFormElements.role.includes(foundUser.role?._id)
+    ) {
+      return false;
+    }
+    if (
+      filterPanelFormElements?.user &&
+      filterPanelFormElements.user !== userId
+    ) {
+      return false;
+    }
+    return true;
+  };
 
   // include the leading/trailing days of the adjacent months that show up
   // as shaded overflow cells on the calendar grid (week starts on Monday)
@@ -168,7 +219,28 @@ export default function ShiftsCalendar() {
             }
           />
         </div>
+        <div className="flex items-center gap-2">
+          <span className="text-sm">{t("Show Filters")}</span>
+          <SwitchButton
+            checked={showFilters}
+            onChange={() => setShowFilters(!showFilters)}
+          />
+        </div>
       </div>
+      <div className={showFilters ? "flex flex-row gap-2" : ""}>
+        {showFilters && (
+          <FilterPanel
+            isFilterPanelActive={showFilters}
+            inputs={filterPanelInputs}
+            formElements={filterPanelFormElements as any}
+            setFormElements={setFilterPanelFormElements as any}
+            closeFilters={() => setShowFilters(false)}
+            additionalFilterCleanFunction={() =>
+              setFilterPanelFormElements({ role: [], user: "" })
+            }
+          />
+        )}
+        <div className="flex-1">
       <MonthlyCalendar
         currentMonth={currentMonth}
         onCurrentMonthChange={(date) => setCurrentMonth(date)}
@@ -190,6 +262,7 @@ export default function ShiftsCalendar() {
               type LocationEntry = {
                 locationId: number;
                 users: string[];
+                displayUsers: string[];
                 shiftRecordId?: number;
                 shiftLabel: string;
                 shiftEndHour?: string;
@@ -264,9 +337,11 @@ export default function ShiftsCalendar() {
                       s.shift === definedShift.shift &&
                       (s.shiftEndHour || "") === (definedShift.shiftEndHour || "")
                   );
+                  const svUsers = sv?.user || [];
                   slot.locationEntries.push({
                     locationId,
-                    users: sv?.user || [],
+                    users: svUsers,
+                    displayUsers: svUsers.filter(matchesShiftFilters),
                     shiftRecordId: shiftRecord?._id,
                     shiftLabel: definedShift.shift,
                     shiftEndHour: definedShift.shiftEndHour,
@@ -336,7 +411,7 @@ export default function ShiftsCalendar() {
                                 </div>
                               )}
                               <div className="flex flex-wrap gap-0.5">
-                                {entry.users.map((userId, idx) => {
+                                {entry.displayUsers.map((userId, idx) => {
                                   const foundUser = getItem(userId, users);
                                   if (!foundUser) return null;
                                   const isChef = entry.chefUser === userId;
@@ -416,6 +491,8 @@ export default function ShiftsCalendar() {
           />
         </MonthlyBody>
       </MonthlyCalendar>
+        </div>
+      </div>
       {activeEntry && (
         <GenericAddEditPanel
           isOpen={isAssignModalOpen}

--- a/src/components/visits/ShiftsCalendar.tsx
+++ b/src/components/visits/ShiftsCalendar.tsx
@@ -419,7 +419,11 @@ export default function ShiftsCalendar() {
       {activeEntry && (
         <GenericAddEditPanel
           isOpen={isAssignModalOpen}
-          close={() => setIsAssignModalOpen(false)}
+          close={() => {
+            setIsAssignModalOpen(false);
+            setActiveEntry(null);
+          }}
+          centerOnMobile
           header={t("Assign Shift")}
           upperMessage={[
             `${t("Location")}: ${
@@ -441,7 +445,7 @@ export default function ShiftsCalendar() {
               required: false,
             },
           ]}
-          formKeys={[{ key: "selectedUsers", type: FormKeyTypeEnum.STRING }]}
+          formKeys={[{ key: "selectedUsers", type: FormKeyTypeEnum.ARRAY }]}
           setForm={setAssignForm as any}
           submitItem={updateShift as any}
           isEditMode={true}
@@ -483,6 +487,7 @@ export default function ShiftsCalendar() {
               });
             }
             setIsAssignModalOpen(false);
+            setActiveEntry(null);
           }}
           topClassName="flex flex-col gap-2"
         />

--- a/src/components/visits/ShiftsCalendar.tsx
+++ b/src/components/visits/ShiftsCalendar.tsx
@@ -1,22 +1,42 @@
-import { endOfMonth, endOfWeek, format, startOfMonth, startOfWeek } from "date-fns";
+import {
+  endOfMonth,
+  endOfWeek,
+  format,
+  isBefore,
+  isSameDay,
+  startOfDay,
+  startOfMonth,
+  startOfWeek,
+} from "date-fns";
+import { enUS, tr } from "date-fns/locale";
 import { useState } from "react";
 import { useTranslation } from "react-i18next";
+import { FaCircle, FaRegCircle, FaRegStar, FaStar } from "react-icons/fa";
+import { GoPlusCircle } from "react-icons/go";
+import { useFilterContext } from "../../context/Filter.context";
 import { useLocationContext } from "../../context/Location.context";
-import { Shift } from "../../types";
+import { useUserContext } from "../../context/User.context";
+import { ActionEnum, DisabledConditionEnum, Shift, ShiftValue } from "../../types";
 import { useGetStoreLocations } from "../../utils/api/location";
-import { useGetShifts } from "../../utils/api/shift";
+import { useGetDisabledConditions } from "../../utils/api/panelControl/disabledCondition";
+import { useGetShifts, useShiftMutations } from "../../utils/api/shift";
 import { useGetUsersMinimal } from "../../utils/api/user";
+import { convertDateFormat } from "../../utils/format";
 import { getItem } from "../../utils/getItem";
 import { MonthlyBody, MonthlyDay } from "../calendar/MonthlyBody";
 import { MonthlyCalendar, MonthlyNav } from "../calendar/MonthlyCalendar";
+import GenericAddEditPanel from "../panelComponents/FormElements/GenericAddEditPanel";
 import ButtonFilter from "../panelComponents/common/ButtonFilter";
+import SwitchButton from "../panelComponents/common/SwitchButton";
+import { FormKeyTypeEnum, InputTypes } from "../panelComponents/shared/types";
 
 type ShiftCalendarEvent = Shift & { date: string };
 
 const DEFAULT_FALLBACK_COLOR = "#6B7280";
 
 export default function ShiftsCalendar() {
-  const { t } = useTranslation();
+  const { t, i18n } = useTranslation();
+  const calendarLocale = i18n.language?.startsWith("tr") ? tr : enUS;
   const [currentMonth, setCurrentMonth] = useState<Date>(
     startOfMonth(new Date())
   );
@@ -26,6 +46,51 @@ export default function ShiftsCalendar() {
   );
   const locations = useGetStoreLocations();
   const users = useGetUsersMinimal();
+  const { user } = useUserContext();
+  const disabledConditions = useGetDisabledConditions();
+  const shiftsDisabledCondition = getItem(
+    DisabledConditionEnum.VISITS_SHIFTS,
+    disabledConditions
+  );
+  const {
+    isChefAssignOpen,
+    setIsChefAssignOpen,
+    isMiddlemanAssignOpen,
+    setIsMiddlemanAssignOpen,
+    isShiftsEnableEdit,
+    setIsShiftsEnableEdit,
+  } = useFilterContext();
+  const canAssignChef = !shiftsDisabledCondition?.actions?.some(
+    (ac) =>
+      ac.action === ActionEnum.ASSIGN_CHEF &&
+      user?.role?._id &&
+      !ac?.permissionsRoles?.includes(user?.role?._id)
+  );
+  const canAssignMiddleman = !shiftsDisabledCondition?.actions?.some(
+    (ac) =>
+      ac.action === ActionEnum.ASSIGN_MIDDLEMAN &&
+      user?.role?._id &&
+      !ac?.permissionsRoles?.includes(user?.role?._id)
+  );
+  const canEnableEdit = !shiftsDisabledCondition?.actions?.some(
+    (ac) =>
+      ac.action === ActionEnum.ENABLEEDIT &&
+      user?.role?._id &&
+      !ac?.permissionsRoles?.includes(user?.role?._id)
+  );
+
+  const [isAssignModalOpen, setIsAssignModalOpen] = useState(false);
+  const [activeEntry, setActiveEntry] = useState<{
+    locationId: number;
+    shiftLabel: string;
+    shiftEndHour?: string;
+    shiftRecordId?: number;
+    day: string;
+    users: string[];
+  } | null>(null);
+  const [assignForm, setAssignForm] = useState<{ selectedUsers: string[] }>({
+    selectedUsers: [],
+  });
 
   // include the leading/trailing days of the adjacent months that show up
   // as shaded overflow cells on the calendar grid (week starts on Monday)
@@ -39,6 +104,11 @@ export default function ShiftsCalendar() {
   );
 
   const shifts = useGetShifts(after, before, selectedLocationId);
+  const { updateShift, createShift } = useShiftMutations(
+    after,
+    before,
+    selectedLocationId
+  );
 
   const events: ShiftCalendarEvent[] = (shifts || []).map((shift) => ({
     ...shift,
@@ -47,6 +117,9 @@ export default function ShiftsCalendar() {
 
   return (
     <div className="__className_a182b8 w-[95%] mx-auto">
+      <div className="mt-4 text-sm text-gray-500">
+        {t("Calendar Info Text")}
+      </div>
       <div className="my-4 flex justify-end">
         <div className="flex gap-2 flex-wrap">
           <ButtonFilter
@@ -66,17 +139,63 @@ export default function ShiftsCalendar() {
           ))}
         </div>
       </div>
+      <div className="my-4 flex justify-end gap-6 flex-wrap">
+        <div className="flex items-center gap-2">
+          <span className="text-sm">{t("Chef Assign")}</span>
+          <SwitchButton
+            checked={isChefAssignOpen}
+            onChange={() =>
+              canAssignChef && setIsChefAssignOpen(!isChefAssignOpen)
+            }
+          />
+        </div>
+        <div className="flex items-center gap-2">
+          <span className="text-sm">{t("Assign Middleman")}</span>
+          <SwitchButton
+            checked={isMiddlemanAssignOpen}
+            onChange={() =>
+              canAssignMiddleman &&
+              setIsMiddlemanAssignOpen(!isMiddlemanAssignOpen)
+            }
+          />
+        </div>
+        <div className="flex items-center gap-2">
+          <span className="text-sm">{t("Enable Edit")}</span>
+          <SwitchButton
+            checked={isShiftsEnableEdit}
+            onChange={() =>
+              canEnableEdit && setIsShiftsEnableEdit(!isShiftsEnableEdit)
+            }
+          />
+        </div>
+      </div>
       <MonthlyCalendar
         currentMonth={currentMonth}
         onCurrentMonthChange={(date) => setCurrentMonth(date)}
+        locale={calendarLocale}
       >
         <MonthlyNav />
         <MonthlyBody<ShiftCalendarEvent> events={events} showOverflowDays>
           <MonthlyDay<ShiftCalendarEvent>
-            renderDay={(dayShifts) => {
-              if (!dayShifts.length) return null;
-
-              type LocationEntry = { locationId: number; users: string[] };
+            listClassName="grid grid-cols-2 gap-x-2 overflow-hidden max-h-36 overflow-y-auto"
+            dayClassName={(day, isOutsideMonth) => {
+              if (isOutsideMonth) return "";
+              const today = startOfDay(new Date());
+              if (isSameDay(day, today)) return "bg-yellow-100";
+              if (isBefore(day, today)) return "bg-red-50";
+              return "";
+            }}
+            renderDay={(dayShifts, day) => {
+              const dayStr = format(day, "yyyy-MM-dd");
+              type LocationEntry = {
+                locationId: number;
+                users: string[];
+                shiftRecordId?: number;
+                shiftLabel: string;
+                shiftEndHour?: string;
+                chefUser?: string;
+                middlemanUser?: string;
+              };
               type SlotEntry = {
                 label: string;
                 startMinutes: number;
@@ -84,24 +203,76 @@ export default function ShiftsCalendar() {
               };
               const slotMap = new Map<string, SlotEntry>();
 
-              dayShifts.forEach((shiftRecord) => {
-                const locationId = shiftRecord.location ?? -1;
-                shiftRecord.shifts?.forEach((sv) => {
-                  const key = `${sv.shift}${sv.shiftEndHour ? `-${sv.shiftEndHour}` : ""}`;
+              const toggleAssignment = (
+                entry: LocationEntry,
+                userId: string,
+                field: "chefUser" | "middlemanUser"
+              ) => {
+                const record = shifts?.find(
+                  (s) => s._id === entry.shiftRecordId
+                );
+                if (!record) return;
+                const updatedShifts = record.shifts?.map((s: ShiftValue) => {
+                  if (
+                    s.shift === entry.shiftLabel &&
+                    (s.shiftEndHour || "") === (entry.shiftEndHour || "")
+                  ) {
+                    return {
+                      ...s,
+                      [field]: s[field] === userId ? "" : userId,
+                    };
+                  }
+                  return s;
+                });
+                updateShift({
+                  id: record._id,
+                  updates: { shifts: updatedShifts },
+                });
+              };
+
+              const locationsToShow =
+                selectedLocationId === -1
+                  ? locations
+                  : locations.filter((l) => l._id === selectedLocationId);
+
+              locationsToShow.forEach((location) => {
+                const locationId = location._id;
+                const shiftRecord = dayShifts.find(
+                  (s) => (s.location ?? -1) === locationId
+                );
+                const definedShifts = location?.shifts?.length
+                  ? location.shifts
+                  : shiftRecord?.shifts;
+
+                definedShifts?.forEach((definedShift) => {
+                  const key = `${definedShift.shift}${
+                    definedShift.shiftEndHour ? `-${definedShift.shiftEndHour}` : ""
+                  }`;
                   let slot = slotMap.get(key);
                   if (!slot) {
-                    const [h, m] = sv.shift.split(":").map(Number);
+                    const [h, m] = definedShift.shift.split(":").map(Number);
                     slot = { label: key, startMinutes: h * 60 + (m || 0), locationEntries: [] };
                     slotMap.set(key, slot);
                   }
                   const existing = slot.locationEntries.find(
                     (e) => e.locationId === locationId
                   );
-                  if (existing) {
-                    existing.users.push(...(sv.user || []));
-                  } else {
-                    slot.locationEntries.push({ locationId, users: sv.user || [] });
-                  }
+                  if (existing) return;
+
+                  const sv = shiftRecord?.shifts?.find(
+                    (s) =>
+                      s.shift === definedShift.shift &&
+                      (s.shiftEndHour || "") === (definedShift.shiftEndHour || "")
+                  );
+                  slot.locationEntries.push({
+                    locationId,
+                    users: sv?.user || [],
+                    shiftRecordId: shiftRecord?._id,
+                    shiftLabel: definedShift.shift,
+                    shiftEndHour: definedShift.shiftEndHour,
+                    chefUser: sv?.chefUser,
+                    middlemanUser: sv?.middlemanUser,
+                  });
                 });
               });
 
@@ -110,48 +281,125 @@ export default function ShiftsCalendar() {
               );
               const isAllMode = selectedLocationId === -1;
 
+              const openAssignModal = (entry: LocationEntry) => {
+                setActiveEntry({
+                  locationId: entry.locationId,
+                  shiftLabel: entry.shiftLabel,
+                  shiftEndHour: entry.shiftEndHour,
+                  shiftRecordId: entry.shiftRecordId,
+                  day: dayStr,
+                  users: entry.users,
+                });
+                setAssignForm({ selectedUsers: entry.users });
+                setIsAssignModalOpen(true);
+              };
+
               return (
                 <>
                   {sortedSlots.map((slot) => {
-                    const hasUsers = slot.locationEntries.some(
-                      (e) => e.users.length > 0
-                    );
-                    if (!hasUsers) return null;
                     return (
                       <li key={slot.label} className="mb-1">
-                        <div className="text-xs font-semibold text-gray-500 mb-0.5">
-                          {slot.label}
+                        <div className="flex items-center gap-1 mb-0.5">
+                          <div className="text-xs font-semibold text-gray-500">
+                            {slot.label}
+                          </div>
+                          {isShiftsEnableEdit && !isAllMode && (
+                            <GoPlusCircle
+                              className="text-green-600 cursor-pointer shrink-0"
+                              onClick={() =>
+                                openAssignModal(slot.locationEntries[0])
+                              }
+                            />
+                          )}
                         </div>
                         {slot.locationEntries.map((entry) => {
-                          if (!entry.users.length) return null;
                           const location = getItem(entry.locationId, locations);
                           return (
                             <div key={entry.locationId} className="mb-0.5">
                               {isAllMode && location && (
-                                <div
-                                  className="text-xs font-semibold mb-0.5"
-                                  style={{
-                                    color:
-                                      location.backgroundColor || DEFAULT_FALLBACK_COLOR,
-                                  }}
-                                >
-                                  {location.name}
+                                <div className="flex items-center gap-1 mb-0.5">
+                                  <div
+                                    className="text-xs font-semibold"
+                                    style={{
+                                      color:
+                                        location.backgroundColor || DEFAULT_FALLBACK_COLOR,
+                                    }}
+                                  >
+                                    {location.name}
+                                  </div>
+                                  {isShiftsEnableEdit && (
+                                    <GoPlusCircle
+                                      className="text-green-600 cursor-pointer shrink-0"
+                                      onClick={() => openAssignModal(entry)}
+                                    />
+                                  )}
                                 </div>
                               )}
                               <div className="flex flex-wrap gap-0.5">
                                 {entry.users.map((userId, idx) => {
                                   const foundUser = getItem(userId, users);
                                   if (!foundUser) return null;
+                                  const isChef = entry.chefUser === userId;
+                                  const isMiddleman =
+                                    entry.middlemanUser === userId;
                                   return (
                                     <span
                                       key={`${userId}-${idx}`}
-                                      className="text-xs px-1 py-0.5 rounded text-white leading-tight"
+                                      className="flex items-center gap-0.5 text-xs px-1 py-0.5 rounded text-white leading-tight"
                                       style={{
                                         backgroundColor:
                                           foundUser.role?.color || DEFAULT_FALLBACK_COLOR,
                                       }}
                                     >
                                       {foundUser.name}
+                                      <span
+                                        className={`text-yellow-300 ${
+                                          isChefAssignOpen && canAssignChef
+                                            ? "cursor-pointer"
+                                            : "cursor-default"
+                                        }`}
+                                        onClick={() => {
+                                          if (!isChefAssignOpen || !canAssignChef)
+                                            return;
+                                          toggleAssignment(
+                                            entry,
+                                            userId,
+                                            "chefUser"
+                                          );
+                                        }}
+                                      >
+                                        {isChef ? (
+                                          <FaStar />
+                                        ) : isChefAssignOpen ? (
+                                          <FaRegStar />
+                                        ) : null}
+                                      </span>
+                                      <span
+                                        className={`text-purple-200 ${
+                                          isMiddlemanAssignOpen &&
+                                          canAssignMiddleman
+                                            ? "cursor-pointer"
+                                            : "cursor-default"
+                                        }`}
+                                        onClick={() => {
+                                          if (
+                                            !isMiddlemanAssignOpen ||
+                                            !canAssignMiddleman
+                                          )
+                                            return;
+                                          toggleAssignment(
+                                            entry,
+                                            userId,
+                                            "middlemanUser"
+                                          );
+                                        }}
+                                      >
+                                        {isMiddleman ? (
+                                          <FaCircle />
+                                        ) : isMiddlemanAssignOpen ? (
+                                          <FaRegCircle />
+                                        ) : null}
+                                      </span>
                                     </span>
                                   );
                                 })}
@@ -168,6 +416,77 @@ export default function ShiftsCalendar() {
           />
         </MonthlyBody>
       </MonthlyCalendar>
+      {activeEntry && (
+        <GenericAddEditPanel
+          isOpen={isAssignModalOpen}
+          close={() => setIsAssignModalOpen(false)}
+          header={t("Assign Shift")}
+          upperMessage={[
+            `${t("Location")}: ${
+              getItem(activeEntry.locationId, locations)?.name ?? ""
+            }`,
+            `${t("Date")}: ${convertDateFormat(activeEntry.day)}`,
+            `${t("Shift")}: ${activeEntry.shiftLabel}${
+              activeEntry.shiftEndHour ? ` - ${activeEntry.shiftEndHour}` : ""
+            }`,
+          ]}
+          inputs={[
+            {
+              type: InputTypes.SELECT,
+              formKey: "selectedUsers",
+              label: t("Selected Users"),
+              options: users?.map((u) => ({ value: u._id, label: u.name })) ?? [],
+              placeholder: t("Selected Users"),
+              isMultiple: true,
+              required: false,
+            },
+          ]}
+          formKeys={[{ key: "selectedUsers", type: FormKeyTypeEnum.STRING }]}
+          setForm={setAssignForm as any}
+          submitItem={updateShift as any}
+          isEditMode={true}
+          constantValues={{ selectedUsers: activeEntry.users }}
+          handleUpdate={() => {
+            const newUsers = assignForm?.selectedUsers ?? [];
+            if (activeEntry.shiftRecordId) {
+              const record = shifts?.find(
+                (s) => s._id === activeEntry.shiftRecordId
+              );
+              const updatedShifts = record?.shifts?.map((s: ShiftValue) => {
+                if (
+                  s.shift === activeEntry.shiftLabel &&
+                  (s.shiftEndHour || "") === (activeEntry.shiftEndHour || "")
+                ) {
+                  return { ...s, user: newUsers };
+                }
+                return s;
+              });
+              updateShift({
+                id: activeEntry.shiftRecordId,
+                updates: { shifts: updatedShifts },
+              });
+            } else {
+              const location = getItem(activeEntry.locationId, locations);
+              const newShifts = location?.shifts?.map((s) => ({
+                shift: s.shift,
+                ...(s.shiftEndHour && { shiftEndHour: s.shiftEndHour }),
+                user:
+                  s.shift === activeEntry.shiftLabel &&
+                  (s.shiftEndHour || "") === (activeEntry.shiftEndHour || "")
+                    ? newUsers
+                    : [],
+              }));
+              createShift({
+                shifts: newShifts,
+                location: activeEntry.locationId,
+                day: activeEntry.day,
+              });
+            }
+            setIsAssignModalOpen(false);
+          }}
+          topClassName="flex flex-col gap-2"
+        />
+      )}
     </div>
   );
 }

--- a/src/locales/en/translation.json
+++ b/src/locales/en/translation.json
@@ -1684,6 +1684,8 @@
   "Assign Game": "Assign Game",
   "Automatically Applied": "Automatically Applied",
   "pcs": "pcs",
-  "off": "off"
+  "off": "off",
+  "Assign Shift": "Assign Shift",
+  "Calendar Info Text": "The yellow cell represents today, red cells represent past dates, and gray cells represent days belonging to the previous/next month shown on the calendar."
 
 }

--- a/src/locales/tr/translation.json
+++ b/src/locales/tr/translation.json
@@ -958,7 +958,7 @@
   "Tables And Orders": "Masalar ve Siparişler",
   "Orders Details": "Sipariş Detayları",
   "Links": "Linkler",
-  "Chef Assign": "Şef Ata",
+  "Chef Assign": "Servis Elemanı Ata",
   "Table Player Counts": "Masa Oyuncu Sayıları",
   "Minimum Base Quantity": "Minimum Baz Miktar",
   "Maximum Base Quantity": "Maksimum Baz Miktar",

--- a/src/locales/tr/translation.json
+++ b/src/locales/tr/translation.json
@@ -1693,5 +1693,7 @@
   "Assign Game": "Oyun Ata",
   "Automatically Applied": "Otomatik Uygulanır",
   "pcs": "ürün",
-  "off": "indirim"
+  "off": "indirim",
+  "Assign Shift": "Vardiya Ata",
+  "Calendar Info Text": "Sarı renkli hücre içinde bulunduğunuz günü, kırmızı renkli hücreler geçmiş tarihleri, gri renkli hücreler takvimde görüntülenen aydan önceki/sonraki aya ait günleri temsil eder."
 }


### PR DESCRIPTION
- Chef/Middleman atama özelliği eklendi.
- Takvim üzerinden doğrudan vardiya ataması özelliği eklendi
- Hücrelerin mobil/desktopta 2 sütun olarak gösterilmesi
- Geçmiş günlerin kırmızı, içinde bulunduğumuz günün sarı gösterilmesi
- Boş vardiyaların da takvimde gösterilmesi