### PR TITLE
Oyun atama penceresinde "test" kullanıcılarının gösterilmemesi

### DIFF
--- a/src/components/games/AssignGame.tsx
+++ b/src/components/games/AssignGame.tsx
@@ -66,6 +66,7 @@ const AssignGame = () => {
           )
           ?.filter(
             (user) =>
+              !user._id.startsWith("test_") &&
               user.userGames &&
               !user.userGames.find(
                 (userGameObject) => userGameObject.game === rowToAction?._id


### PR DESCRIPTION
Abi selamlar, backendde user'a "isTestUser" diye bir field ekleyip /users adresinden de o fieldın değerini setleyip, oyun atamalarından da isTestUser şeklinde filtreletecektim ama bu şekilde daha pratik geldi, öyle yapalım derseniz ona çevireyim, böyle okeyse bunu alalım