### PR TITLE
/order-datas adresinde "Da Vinci Oyunları" gösterimi için geliştirmeler

### DIFF
--- a/src/components/menu/MenuItemTable.tsx
+++ b/src/components/menu/MenuItemTable.tsx
@@ -113,6 +113,7 @@ const MenuItemTable = ({ singleItemGroup, popularItems }: Props) => {
   const initialBulkInputForm = {
     productCategories: [],
     price: 0,
+    isDaVinciGame: false,
     bulkEditSelection: [],
   };
   const [bulkInputForm, setBulkInputForm] = useState({
@@ -363,6 +364,10 @@ const MenuItemTable = ({ singleItemGroup, popularItems }: Props) => {
         _id: "price",
         label: t("Price"),
       },
+      {
+        _id: "isDaVinciGame",
+        label: t("Da Vinci Game"),
+      },
     ],
     [t]
   );
@@ -409,6 +414,18 @@ const MenuItemTable = ({ singleItemGroup, popularItems }: Props) => {
           !(bulkInputForm?.bulkEditSelection as string[])?.includes("price"),
         required: false,
       },
+      {
+        type: InputTypes.CHECKBOX,
+        formKey: "isDaVinciGame",
+        label: t("Da Vinci Game"),
+        placeholder: t("Da Vinci Game"),
+        isDisabled:
+          !isEditSelectionCompeted ||
+          !(bulkInputForm?.bulkEditSelection as string[])?.includes(
+            "isDaVinciGame"
+          ),
+        required: false,
+      },
     ],
     [
       t,
@@ -424,6 +441,7 @@ const MenuItemTable = ({ singleItemGroup, popularItems }: Props) => {
       { key: "bulkEditSelection", type: FormKeyTypeEnum.STRING },
       // { key: "productCategories", type: FormKeyTypeEnum.STRING },
       { key: "price", type: FormKeyTypeEnum.NUMBER },
+      { key: "isDaVinciGame", type: FormKeyTypeEnum.BOOLEAN },
     ],
     []
   );

--- a/src/components/menu/MenuItemTable.tsx
+++ b/src/components/menu/MenuItemTable.tsx
@@ -637,6 +637,13 @@ const MenuItemTable = ({ singleItemGroup, popularItems }: Props) => {
         placeholder: t("Barcode"),
         required: false,
       },
+      {
+        type: InputTypes.CHECKBOX,
+        formKey: "isDaVinciGame",
+        label: t("Da Vinci Game"),
+        placeholder: t("Da Vinci Game"),
+        required: false,
+      },
       ...(singleItemGroup?.category?.isLimitedTime
         ? [
             {
@@ -679,6 +686,7 @@ const MenuItemTable = ({ singleItemGroup, popularItems }: Props) => {
       { key: "hepsiBuradaSku", type: FormKeyTypeEnum.STRING },
       { key: "sku", type: FormKeyTypeEnum.STRING },
       { key: "barcode", type: FormKeyTypeEnum.STRING },
+      { key: "isDaVinciGame", type: FormKeyTypeEnum.BOOLEAN },
       { key: "startDate", type: FormKeyTypeEnum.STRING },
       { key: "endDate", type: FormKeyTypeEnum.STRING },
     ],

--- a/src/components/orderDatas/CategoryBasedSalesReport.tsx
+++ b/src/components/orderDatas/CategoryBasedSalesReport.tsx
@@ -24,7 +24,7 @@ import { useGetOrderDiscounts } from "../../utils/api/order/orderDiscount";
 import { useGetDisabledConditions } from "../../utils/api/panelControl/disabledCondition";
 import { useGetUsersMinimal } from "../../utils/api/user";
 import { formatCurrency, formatPercentage } from "../../utils/format";
-import { getItem } from "../../utils/getItem";
+import { getCategoryFilterOptions, getItem } from "../../utils/getItem";
 import { isActionDisabled } from "../../utils/permissions";
 import { QuickDateRangeFilter } from "../common/QuickDateRangeFilter";
 import GenericTable from "../panelComponents/Tables/GenericTable";
@@ -453,12 +453,7 @@ const CategoryBasedSalesReport = () => {
         type: InputTypes.SELECT,
         formKey: "category",
         label: t("Category"),
-        options: categories?.map((category) => {
-          return {
-            value: category?._id,
-            label: category?.name,
-          };
-        }),
+        options: getCategoryFilterOptions(categories, t),
         isMultiple: true,
         placeholder: t("Category"),
         required: true,

--- a/src/components/orderDatas/DiscountBasedSales.tsx
+++ b/src/components/orderDatas/DiscountBasedSales.tsx
@@ -25,7 +25,7 @@ import { useGetOrderDiscounts } from "../../utils/api/order/orderDiscount";
 import { useGetDisabledConditions } from "../../utils/api/panelControl/disabledCondition";
 import { useGetTables } from "../../utils/api/table";
 import { useGetUsersMinimal } from "../../utils/api/user";
-import { getItem } from "../../utils/getItem";
+import { getCategoryFilterOptions, getItem } from "../../utils/getItem";
 import { passesFilter } from "../../utils/passesFilter";
 import { isActionDisabled } from "../../utils/permissions";
 import { QuickDateRangeFilter } from "../common/QuickDateRangeFilter";
@@ -433,12 +433,7 @@ const DiscountBasedSales = () => {
         type: InputTypes.SELECT,
         formKey: "category",
         label: t("Category"),
-        options: categories?.map((category) => {
-          return {
-            value: category?._id,
-            label: category?.name,
-          };
-        }),
+        options: getCategoryFilterOptions(categories, t),
         isMultiple: true,
         placeholder: t("Category"),
         required: true,

--- a/src/components/orderDatas/GroupedProductSalesReport.tsx
+++ b/src/components/orderDatas/GroupedProductSalesReport.tsx
@@ -26,7 +26,7 @@ import { useGetOrders } from "../../utils/api/order/order";
 import { useGetOrderDiscounts } from "../../utils/api/order/orderDiscount";
 import { useGetDisabledConditions } from "../../utils/api/panelControl/disabledCondition";
 import { useGetUsersMinimal } from "../../utils/api/user";
-import { getItem } from "../../utils/getItem";
+import { getCategoryFilterOptions, getItem } from "../../utils/getItem";
 import { isActionDisabled } from "../../utils/permissions";
 import { QuickDateRangeFilter } from "../common/QuickDateRangeFilter";
 import GenericTable from "../panelComponents/Tables/GenericTable";
@@ -426,12 +426,7 @@ const GroupedProductSalesReport = () => {
         type: InputTypes.SELECT,
         formKey: "category",
         label: t("Category"),
-        options: categories?.map((category) => {
-          return {
-            value: category?._id,
-            label: category?.name,
-          };
-        }),
+        options: getCategoryFilterOptions(categories, t),
         isMultiple: true,
         placeholder: t("Category"),
         required: true,

--- a/src/components/orderDatas/SingleProductSalesReport.tsx
+++ b/src/components/orderDatas/SingleProductSalesReport.tsx
@@ -26,7 +26,7 @@ import { useGetOrders } from "../../utils/api/order/order";
 import { useGetOrderDiscounts } from "../../utils/api/order/orderDiscount";
 import { useGetDisabledConditions } from "../../utils/api/panelControl/disabledCondition";
 import { useGetUsersMinimal } from "../../utils/api/user";
-import { getItem } from "../../utils/getItem";
+import { getCategoryFilterOptions, getItem } from "../../utils/getItem";
 import { isActionDisabled } from "../../utils/permissions";
 import { QuickDateRangeFilter } from "../common/QuickDateRangeFilter";
 import GenericTable from "../panelComponents/Tables/GenericTable";
@@ -340,12 +340,7 @@ const SingleProductSalesReport = () => {
         type: InputTypes.SELECT,
         formKey: "category",
         label: t("Category"),
-        options: categories?.map((category) => {
-          return {
-            value: category?._id,
-            label: category?.name,
-          };
-        }),
+        options: getCategoryFilterOptions(categories, t),
         isMultiple: true,
         placeholder: t("Category"),
         required: true,

--- a/src/components/orderDatas/UpperCategoryBasedSalesReport.tsx
+++ b/src/components/orderDatas/UpperCategoryBasedSalesReport.tsx
@@ -26,7 +26,7 @@ import { useGetOrderDiscounts } from "../../utils/api/order/orderDiscount";
 import { useGetDisabledConditions } from "../../utils/api/panelControl/disabledCondition";
 import { useGetUsersMinimal } from "../../utils/api/user";
 import { formatCurrency, formatPercentage } from "../../utils/format";
-import { getItem } from "../../utils/getItem";
+import { getCategoryFilterOptions, getItem } from "../../utils/getItem";
 import { isActionDisabled } from "../../utils/permissions";
 import { QuickDateRangeFilter } from "../common/QuickDateRangeFilter";
 import GenericTable from "../panelComponents/Tables/GenericTable";
@@ -546,12 +546,7 @@ const UpperCategoryBasedSalesReport = () => {
         type: InputTypes.SELECT,
         formKey: "category",
         label: t("Category"),
-        options: categories?.map((category) => {
-          return {
-            value: category?._id,
-            label: category?.name,
-          };
-        }),
+        options: getCategoryFilterOptions(categories, t),
         isMultiple: true,
         placeholder: t("Category"),
         required: true,

--- a/src/locales/en/translation.json
+++ b/src/locales/en/translation.json
@@ -1688,6 +1688,8 @@
   "pcs": "pcs",
   "off": "off",
   "Assign Shift": "Assign Shift",
-  "Calendar Info Text": "The yellow cell represents today, red cells represent past dates, and gray cells represent days belonging to the previous/next month shown on the calendar."
+  "Calendar Info Text": "The yellow cell represents today, red cells represent past dates, and gray cells represent days belonging to the previous/next month shown on the calendar.",
+  "Da Vinci Games": "Da Vinci Games",
+  "Da Vinci Game": "Is Da Vinci Game?"
 
 }

--- a/src/locales/tr/translation.json
+++ b/src/locales/tr/translation.json
@@ -1697,5 +1697,7 @@
   "pcs": "ürün",
   "off": "indirim",
   "Assign Shift": "Vardiya Ata",
-  "Calendar Info Text": "Sarı renkli hücre içinde bulunduğunuz günü, kırmızı renkli hücreler geçmiş tarihleri, gri renkli hücreler takvimde görüntülenen aydan önceki/sonraki aya ait günleri temsil eder."
+  "Calendar Info Text": "Sarı renkli hücre içinde bulunduğunuz günü, kırmızı renkli hücreler geçmiş tarihleri, gri renkli hücreler takvimde görüntülenen aydan önceki/sonraki aya ait günleri temsil eder.",
+  "Da Vinci Games": "Da Vinci Oyunları",
+  "Da Vinci Game": "Da Vinci oyunu mu?"
 }

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -818,6 +818,11 @@ export type Kitchen = {
   isPrintEnabled?: boolean;
 };
 
+/** Sentinel value sent as a fake `category` filter option to ask the
+ * backend for items where `isDaVinciGame` is true. Must match
+ * DAVINCI_GAME_CATEGORY_FILTER_VALUE in the backend's order.dto.ts. */
+export const DAVINCI_GAME_CATEGORY_FILTER_VALUE = "davinci-games";
+
 export type MenuItem = {
   trendyolBarcode: unknown;
   hepsiBuradaSku?: unknown;
@@ -833,6 +838,7 @@ export type MenuItem = {
   order: number;
   isAutoServed?: boolean;
   isAutoPrepared?: boolean;
+  isDaVinciGame?: boolean;
   itemProduction?: {
     product: string;
     quantity: number;

--- a/src/utils/getItem.ts
+++ b/src/utils/getItem.ts
@@ -62,11 +62,11 @@ export function menuItemHasDecrementStock(
 export function getCategoryFilterOptions(
   categories: MenuCategory[] | undefined,
   t: (key: string) => string
-) {
+): { value: string | number; label: string }[] {
   return [
     ...(categories ?? []).map((category) => ({
-      value: category?._id,
-      label: category?.name,
+      value: category._id,
+      label: category.name,
     })),
     {
       value: DAVINCI_GAME_CATEGORY_FILTER_VALUE,

--- a/src/utils/getItem.ts
+++ b/src/utils/getItem.ts
@@ -1,4 +1,8 @@
-import { MenuCategory, MenuItem } from "../types";
+import {
+  DAVINCI_GAME_CATEGORY_FILTER_VALUE,
+  MenuCategory,
+  MenuItem,
+} from "../types";
 
 export function getRefId(
   ref: string | number | { _id: string | number }
@@ -51,4 +55,22 @@ export function menuItemHasDecrementStock(
   item: MenuItem | undefined
 ): boolean {
   return item?.itemProduction?.some((p) => p.isDecrementStock) ?? false;
+}
+
+/** Category filter SELECT options for order data reports: real categories
+ * plus a fake "Da Vinci Games" option that filters items by isDaVinciGame. */
+export function getCategoryFilterOptions(
+  categories: MenuCategory[] | undefined,
+  t: (key: string) => string
+) {
+  return [
+    ...(categories ?? []).map((category) => ({
+      value: category?._id,
+      label: category?.name,
+    })),
+    {
+      value: DAVINCI_GAME_CATEGORY_FILTER_VALUE,
+      label: t("Da Vinci Games"),
+    },
+  ];
 }


### PR DESCRIPTION
- MenuItem tipine isDaVinciGame alanı eklendi.
- /menu sayfasındaki ürün ekleme/düzenleme modalına "Da Vinci Game" checkbox'ı eklendi.
- /order-datas altındaki 5 rapor sayfasının (Ürün Bazlı Satış, Ürün Bazlı Satış-Toplu, Üst Kategori Bazlı Satışlar, Kategori Bazlı Satış, İndirim Bazlı Satış) filtre penceresindeki Kategori dropdown'una "Da Vinci Games" seçeneği eklendi.
- Bu seçeneği oluşturan tekrarlayan kod, ortak bir yardımcı fonksiyona (getCategoryFilterOptions) taşınarak sadeleştirildi.
- Türkçe/İngilizce çeviri dosyalarına ilgili metinler eklendi.