### PR TITLE
Tıklanabilir algısı yaratan mavi indirim shopify kodlarının siyah yapılması ve müşteri listesindeki try değişimi

### DIFF
--- a/src/components/accounting/ShopifyDiscounts.tsx
+++ b/src/components/accounting/ShopifyDiscounts.tsx
@@ -452,7 +452,7 @@ const ShopifyDiscounts = () => {
 
   const columns = useMemo(
     () => [
-      { key: t("Code"), isSortable: false },
+      { key: t("Discount Code"), isSortable: false },
       { key: t("Title"), isSortable: false },
       { key: t("Discount Type"), isSortable: false },
       { key: t("Value"), isSortable: false },
@@ -470,7 +470,7 @@ const ShopifyDiscounts = () => {
       {
         key: "code",
         node: (row: DiscountRow) => (
-          <span className="font-mono font-semibold text-blue-700">{row.code}</span>
+          <span className="font-mono font-semibold">{row.code}</span>
         ),
       },
       { key: "title" },

--- a/src/components/consumer/ShopifyCustomers.tsx
+++ b/src/components/consumer/ShopifyCustomers.tsx
@@ -87,7 +87,7 @@ const ShopifyCustomers = () => {
       {
         key: "amountSpent",
         node: (row: ShopifyAdminCustomer) =>
-          `${parseFloat(row.amountSpent?.amount ?? "0").toFixed(2)} ${row.amountSpent?.currencyCode ?? ""}`,
+          `₺${parseFloat(row.amountSpent?.amount ?? "0").toFixed(2)}`,
       },
     ],
     []


### PR DESCRIPTION
İndirim kodu kolonunda tıklanabilir algısı oluşturn mavi satırlar siyah yapıldı