### PR TITLE
/menu'deki ürün ve kategori ekranlarında yapılan geri bildirime dair geliştirme

### DIFF
--- a/src/components/menu/ItemPlatformSalesTable.tsx
+++ b/src/components/menu/ItemPlatformSalesTable.tsx
@@ -37,10 +37,10 @@ const ORDER_NUMBER_KEY: Record<ItemPlatformKey, keyof ItemPlatformOrder> = {
 type PlatformOrderRow = {
   _id: string;
   dateDisplay: string;
+  hourDisplay: string;
   orderNumberDisplay: string;
   quantityDisplay: number | string;
   unitPriceDisplay: string;
-  statusDisplay: string;
   isLoadMore?: boolean;
 };
 
@@ -213,22 +213,22 @@ export default function ItemPlatformSalesTable({ item }: Props) {
         const orders = ordersByPlatform[platform.key];
         const collapsibleRows: PlatformOrderRow[] = orders.map((order) => ({
           _id: String(order._id),
-          dateDisplay: format(toIstDate(order.createdAt), "dd/MM/yyyy HH:mm"),
+          dateDisplay: format(toIstDate(order.createdAt), "dd/MM/yyyy"),
+          hourDisplay: format(toIstDate(order.createdAt), "HH:mm"),
           orderNumberDisplay:
             (order[ORDER_NUMBER_KEY[platform.key]] as string) || "-",
           quantityDisplay: order.quantity,
           unitPriceDisplay: `${formatCurrency(order.unitPrice)} ${TURKISHLIRA}`,
-          statusDisplay: order.status,
         }));
 
         if (hasMoreByPlatform[platform.key]) {
           collapsibleRows.push({
             _id: `${platform.key}-load-more`,
             dateDisplay: "",
+            hourDisplay: "",
             orderNumberDisplay: "",
             quantityDisplay: "",
             unitPriceDisplay: "",
-            statusDisplay: "",
             isLoadMore: true,
           });
         }
@@ -259,9 +259,9 @@ export default function ItemPlatformSalesTable({ item }: Props) {
           collapsible: {
             collapsibleColumns: [
               { key: t("Date"), isSortable: false },
+              { key: t("Hour"), isSortable: false },
               { key: t("Order Number"), isSortable: false },
               { key: t("Quantity"), isSortable: false },
-              { key: t("Status"), isSortable: false },
             ],
             collapsibleRows,
             collapsibleRowKeys: [
@@ -270,9 +270,9 @@ export default function ItemPlatformSalesTable({ item }: Props) {
                 node: dateOrLoadMoreNode,
                 className: "min-w-32",
               },
+              { key: "hourDisplay", className: "min-w-20" },
               { key: "orderNumberDisplay", className: "min-w-32" },
               { key: "quantityDisplay", className: "min-w-20" },
-              { key: "statusDisplay", className: "min-w-24" },
             ],
           },
         };

--- a/src/components/menu/ItemPlatformSalesTable.tsx
+++ b/src/components/menu/ItemPlatformSalesTable.tsx
@@ -211,15 +211,18 @@ export default function ItemPlatformSalesTable({ item }: Props) {
     () =>
       availablePlatforms.map((platform) => {
         const orders = ordersByPlatform[platform.key];
-        const collapsibleRows: PlatformOrderRow[] = orders.map((order) => ({
-          _id: String(order._id),
-          dateDisplay: format(toIstDate(order.createdAt), "dd/MM/yyyy"),
-          hourDisplay: format(toIstDate(order.createdAt), "HH:mm"),
-          orderNumberDisplay:
-            (order[ORDER_NUMBER_KEY[platform.key]] as string) || "-",
-          quantityDisplay: order.quantity,
-          unitPriceDisplay: `${formatCurrency(order.unitPrice)} ${TURKISHLIRA}`,
-        }));
+        const collapsibleRows: PlatformOrderRow[] = orders.map((order) => {
+          const zonedDate = toIstDate(order.createdAt);
+          return {
+            _id: String(order._id),
+            dateDisplay: format(zonedDate, "dd/MM/yyyy"),
+            hourDisplay: format(zonedDate, "HH:mm"),
+            orderNumberDisplay:
+              (order[ORDER_NUMBER_KEY[platform.key]] as string) || "-",
+            quantityDisplay: order.quantity,
+            unitPriceDisplay: `${formatCurrency(order.unitPrice)} ${TURKISHLIRA}`,
+          };
+        });
 
         if (hasMoreByPlatform[platform.key]) {
           collapsibleRows.push({

--- a/src/components/menu/MenuItemTable.tsx
+++ b/src/components/menu/MenuItemTable.tsx
@@ -758,6 +758,7 @@ const MenuItemTable = ({ singleItemGroup, popularItems }: Props) => {
       { key: t("Shown In Menu"), isSortable: false },
       // { key: t("Auto Served"), isSortable: false },
       { key: t("Auto Prepared"), isSortable: false },
+      { key: t("Da Vinci Game"), isSortable: false },
     ];
 
     const keys: RowKeyType<
@@ -962,6 +963,25 @@ const MenuItemTable = ({ singleItemGroup, popularItems }: Props) => {
                   updates: {
                     ...row,
                     isAutoPrepared: !row.isAutoPrepared,
+                  },
+                });
+              }}
+            />
+          );
+        },
+      },
+      {
+        key: "isDaVinciGame",
+        node: (row: MenuItem) => {
+          return (
+            <CheckSwitch
+              checked={row?.isDaVinciGame ?? false}
+              onChange={() => {
+                updateItem({
+                  id: row._id,
+                  updates: {
+                    ...row,
+                    isDaVinciGame: !row.isDaVinciGame,
                   },
                 });
               }}

--- a/src/components/menu/MenuItemTable.tsx
+++ b/src/components/menu/MenuItemTable.tsx
@@ -789,21 +789,27 @@ const MenuItemTable = ({ singleItemGroup, popularItems }: Props) => {
         className: "min-w-48 pr-1",
         node: (item: MenuItem) => {
           if (!item?.description) return null;
+          const DESCRIPTION_PREVIEW_LENGTH = 40;
+          const description = item.description;
+          const isTruncatable = description.length > DESCRIPTION_PREVIEW_LENGTH;
           const isOpen = openDescriptionId === item._id;
+          const previewText = isTruncatable
+            ? `${description.slice(0, DESCRIPTION_PREVIEW_LENGTH)}...`
+            : description;
           return (
             <div className="flex flex-col gap-1">
-              <button
-                onClick={() =>
-                  setOpenDescriptionId(isOpen ? null : item._id)
-                }
-                className="flex items-center gap-1 text-xl text-gray-700 hover:text-gray-900"
-              >
-                {isOpen ? <IoChevronUp /> : <IoChevronDown />}
-              </button>
-              {isOpen && (
-                <p className="max-w-64 whitespace-pre-wrap">
-                  {item.description}
-                </p>
+              <p className="max-w-64 whitespace-pre-wrap">
+                {isOpen ? description : previewText}
+              </p>
+              {isTruncatable && (
+                <button
+                  onClick={() =>
+                    setOpenDescriptionId(isOpen ? null : item._id)
+                  }
+                  className="flex items-center text-xl text-gray-700 hover:text-gray-900"
+                >
+                  {isOpen ? <IoChevronUp /> : <IoChevronDown />}
+                </button>
               )}
             </div>
           );

--- a/src/locales/en/translation.json
+++ b/src/locales/en/translation.json
@@ -1692,7 +1692,7 @@
   "Assign Shift": "Assign Shift",
   "Calendar Info Text": "The yellow cell represents today, red cells represent past dates, and gray cells represent days belonging to the previous/next month shown on the calendar.",
   "Da Vinci Games": "Da Vinci Games",
-  "Da Vinci Game": "Is Da Vinci Game?",
+  "Da Vinci Game": "Da Vinci Game",
   "Price History": "Price History",
   "Sold Quantity": "Sold Quantity",
   "Order Count": "Order Count",

--- a/src/locales/tr/translation.json
+++ b/src/locales/tr/translation.json
@@ -1701,7 +1701,7 @@
   "Assign Shift": "Vardiya Ata",
   "Calendar Info Text": "Sarı renkli hücre içinde bulunduğunuz günü, kırmızı renkli hücreler geçmiş tarihleri, gri renkli hücreler takvimde görüntülenen aydan önceki/sonraki aya ait günleri temsil eder.",
   "Da Vinci Games": "Da Vinci Oyunları",
-  "Da Vinci Game": "Da Vinci oyunu mu?",
+  "Da Vinci Game": "Da Vinci Oyunu",
   "Price History": "Fiyat Geçmişi",
   "Sold Quantity": "Satılan Miktar",
   "Order Count": "Sipariş Sayısı",


### PR DESCRIPTION
- Tarih kolonunda hem tarih hem saat görüntüleniyordu, ayrıldı.
- Durum kolonu kaldırıldı
- Ürünün da vinci oyunu olup-olmamasının direkt tablo üzerindeki switch ile belirlenmesi sağlandı.
- Ürün açıklamasındaki ok işaretinin düzeltilmesi(açıklamanın bir kısmı görünecek şekilde)