### PR TITLE
/orders sayfasına kullanıcı seçimi bölümü eklenmesi ve 'servis edildi' kolonundaki gruplu satırların her iptal/geri işlemlerinde otomatik kapanmaması

### DIFF
--- a/src/components/orders/OrderStatusContainer.tsx
+++ b/src/components/orders/OrderStatusContainer.tsx
@@ -85,17 +85,18 @@ const OrderStatusContainer = ({
       [tableId]: !prev[tableId],
     }));
   };
-  const groupedOrders = orders.reduce<{ [key: string]: Order[] }>(
-    (acc, order) => {
-      const tableId = (order?.table as Table)?._id;
-      if (!acc[tableId]) {
-        acc[tableId] = [];
-      }
+  const groupedOrders = useMemo(
+    () =>
+      orders.reduce<{ [key: string]: Order[] }>((acc, order) => {
+        const tableId = (order?.table as Table)?._id;
+        if (!acc[tableId]) {
+          acc[tableId] = [];
+        }
 
-      acc[tableId].push(order);
-      return acc;
-    },
-    {}
+        acc[tableId].push(order);
+        return acc;
+      }, {}),
+    [orders]
   );
   const getEarliestDate = (orders: Order[]): Date | null => {
     return orders.reduce<Date | null>((earliest, order) => {
@@ -123,20 +124,24 @@ const OrderStatusContainer = ({
     }, null);
   };
 
-  const sortedGroupedOrders = Object.entries(groupedOrders).sort((a, b) => {
-    const earliestA = getEarliestDate(a[1]);
-    const earliestB = getEarliestDate(b[1]);
-    if (earliestA === null && earliestB === null) {
-      return 0;
-    }
-    if (earliestA === null) {
-      return 1;
-    }
-    if (earliestB === null) {
-      return -1;
-    }
-    return earliestB.getTime() - earliestA.getTime();
-  });
+  const sortedGroupedOrders = useMemo(
+    () =>
+      Object.entries(groupedOrders).sort((a, b) => {
+        const earliestA = getEarliestDate(a[1]);
+        const earliestB = getEarliestDate(b[1]);
+        if (earliestA === null && earliestB === null) {
+          return 0;
+        }
+        if (earliestA === null) {
+          return 1;
+        }
+        if (earliestB === null) {
+          return -1;
+        }
+        return earliestB.getTime() - earliestA.getTime();
+      }),
+    [groupedOrders]
+  );
   useEffect(() => {
     const currentTableIds = new Set(
       sortedGroupedOrders.map(([tableId]) => tableId)
@@ -159,7 +164,7 @@ const OrderStatusContainer = ({
       }
       return hasChanges ? next : prev;
     });
-  }, [orders]);
+  }, [sortedGroupedOrders, status]);
 
   const { mutate: updateMultipleOrders } = useUpdateMultipleOrderMutation();
   const showPrint = useMemo(() => {

--- a/src/components/orders/OrderStatusContainer.tsx
+++ b/src/components/orders/OrderStatusContainer.tsx
@@ -6,6 +6,7 @@ import { useUserContext } from "../../context/User.context";
 import useIsSmallScreen from "../../hooks/useIsSmallScreen";
 import { Kitchen, Order, OrderStatus, Table } from "../../types";
 import { useUpdateMultipleOrderMutation } from "../../utils/api/order/order";
+import { MinimalUser } from "../../utils/api/user";
 import { printTableReceipt } from "../../utils/printReceipt";
 import SingleOrderCard from "./SingleOrderCard";
 
@@ -15,6 +16,7 @@ type Props = {
   icon: React.ReactNode;
   iconBackgroundColor: string;
   kitchen: Kitchen;
+  actionUser: MinimalUser;
   defaultCollapsed?: boolean;
 };
 
@@ -24,6 +26,7 @@ const OrderStatusContainer = ({
   icon,
   iconBackgroundColor,
   kitchen,
+  actionUser,
   defaultCollapsed = false,
 }: Props) => {
   const { t } = useTranslation();
@@ -135,15 +138,27 @@ const OrderStatusContainer = ({
     return earliestB.getTime() - earliestA.getTime();
   });
   useEffect(() => {
-    for (const [tableId, tableOrders] of sortedGroupedOrders) {
-      const isTableOpen = !(tableOrders[0]?.table as Table)?.finishHour;
-      if (isTableOpen) {
-        setExpandedTables((prev) => ({
-          ...prev,
-          [tableId]: status !== "Served",
-        }));
+    const currentTableIds = new Set(
+      sortedGroupedOrders.map(([tableId]) => tableId)
+    );
+    setExpandedTables((prev) => {
+      const next = { ...prev };
+      let hasChanges = false;
+      for (const tableId of Object.keys(next)) {
+        if (!currentTableIds.has(tableId)) {
+          delete next[tableId];
+          hasChanges = true;
+        }
       }
-    }
+      for (const [tableId, tableOrders] of sortedGroupedOrders) {
+        const isTableOpen = !(tableOrders[0]?.table as Table)?.finishHour;
+        if (isTableOpen && !(tableId in next)) {
+          next[tableId] = status !== "Served";
+          hasChanges = true;
+        }
+      }
+      return hasChanges ? next : prev;
+    });
   }, [orders]);
 
   const { mutate: updateMultipleOrders } = useUpdateMultipleOrderMutation();
@@ -226,7 +241,7 @@ const OrderStatusContainer = ({
                         updates: {
                           status: OrderStatus.READYTOSERVE,
                           preparedAt: new Date(),
-                          preparedBy: user._id,
+                          preparedBy: actionUser._id,
                         },
                       });
                     }}
@@ -245,7 +260,7 @@ const OrderStatusContainer = ({
                         updates: {
                           status: OrderStatus.SERVED,
                           deliveredAt: new Date(),
-                          deliveredBy: user._id,
+                          deliveredBy: actionUser._id,
                         },
                       });
                     }}
@@ -263,6 +278,7 @@ const OrderStatusContainer = ({
                       key={order._id}
                       order={order}
                       user={user}
+                      actionUser={actionUser}
                     />
                   ))}
                 </div>

--- a/src/components/orders/SingleOrderCard.tsx
+++ b/src/components/orders/SingleOrderCard.tsx
@@ -8,6 +8,7 @@ import {
   useCreateOrderForDivideMutation,
   useOrderMutations,
 } from "../../utils/api/order/order";
+import { MinimalUser } from "../../utils/api/user";
 import { getItem } from "../../utils/getItem";
 import { GenericButton } from "../common/GenericButton";
 import CommonSelectInput from "../common/SelectInput";
@@ -16,9 +17,10 @@ import Timer from "../common/Timer";
 type Props = {
   order: Order;
   user: User;
+  actionUser: MinimalUser;
 };
 
-const SingleOrderCard = ({ order, user }: Props) => {
+const SingleOrderCard = ({ order, user, actionUser }: Props) => {
   const { updateOrder } = useOrderMutations();
   const { mutate: cancelOrder } = useCancelOrderMutation();
   const { mutate: createOrderForDivide } = useCreateOrderForDivideMutation();
@@ -169,7 +171,7 @@ const SingleOrderCard = ({ order, user }: Props) => {
                   updates: {
                     status: OrderStatus.CANCELLED,
                     cancelledAt: new Date(),
-                    cancelledBy: user._id,
+                    cancelledBy: actionUser._id,
                   },
                   tableId,
                 });
@@ -190,7 +192,7 @@ const SingleOrderCard = ({ order, user }: Props) => {
                   updates: {
                     status: OrderStatus.PENDING,
                     confirmedAt: new Date(),
-                    confirmedBy: user._id,
+                    confirmedBy: actionUser._id,
                   },
                 });
               }}
@@ -242,7 +244,7 @@ const SingleOrderCard = ({ order, user }: Props) => {
                   updates: {
                     status: OrderStatus.READYTOSERVE,
                     preparedAt: new Date(),
-                    preparedBy: user._id,
+                    preparedBy: actionUser._id,
                   },
                 });
               }}
@@ -262,7 +264,7 @@ const SingleOrderCard = ({ order, user }: Props) => {
                     updates: {
                       status: OrderStatus.SERVED,
                       deliveredAt: new Date(),
-                      deliveredBy: user._id,
+                      deliveredBy: actionUser._id,
                     },
                   });
                 }}
@@ -274,26 +276,25 @@ const SingleOrderCard = ({ order, user }: Props) => {
               </GenericButton>
             </div>
           )}
-          {order?.status === OrderStatus.SERVED &&
-            user._id === order?.deliveredBy && (
-              <div className="flex flex-row ">
-                <GenericButton
-                  onClick={() => {
-                    updateOrder({
-                      id: order?._id,
-                      updates: {
-                        status: OrderStatus.READYTOSERVE,
-                      },
-                    });
-                  }}
-                  variant="ghost"
-                  size="sm"
-                  className="text-gray-600 hover:text-black border border-gray-300"
-                >
-                  {t("Back")}
-                </GenericButton>
-              </div>
-            )}
+          {order?.status === OrderStatus.SERVED && (
+            <div className="flex flex-row ">
+              <GenericButton
+                onClick={() => {
+                  updateOrder({
+                    id: order?._id,
+                    updates: {
+                      status: OrderStatus.READYTOSERVE,
+                    },
+                  });
+                }}
+                variant="ghost"
+                size="sm"
+                className="text-gray-600 hover:text-black border border-gray-300"
+              >
+                {t("Back")}
+              </GenericButton>
+            </div>
+          )}
         </div>
       </div>
     </div>

--- a/src/components/orders/SingleOrdersPage.tsx
+++ b/src/components/orders/SingleOrdersPage.tsx
@@ -6,14 +6,16 @@ import { useLocationContext } from "../../context/Location.context";
 import { useUserContext } from "../../context/User.context";
 import { Kitchen, Order, OrderStatus, RoleEnum } from "../../types";
 import { useGetAllCategories } from "../../utils/api/menu/category";
+import { MinimalUser } from "../../utils/api/user";
 import { getItem } from "../../utils/getItem";
 import OrderStatusContainer from "../orders/OrderStatusContainer";
 
 type Props = {
   kitchen: Kitchen;
   orders: Order[];
+  actionUser: MinimalUser;
 };
-const SingleOrdersPage = ({ kitchen, orders }: Props) => {
+const SingleOrdersPage = ({ kitchen, orders, actionUser }: Props) => {
   const { selectedLocationId } = useLocationContext();
   const categories = useGetAllCategories();
   const { menuItems: items } = useDataContext();
@@ -85,6 +87,7 @@ const SingleOrdersPage = ({ kitchen, orders }: Props) => {
                   icon={orderStatus.icon}
                   iconBackgroundColor={orderStatus.iconBackgroundColor}
                   kitchen={kitchen}
+                  actionUser={actionUser}
                   defaultCollapsed={
                     orderStatus.smallScreenOpenForRoles
                       ? !orderStatus.smallScreenOpenForRoles.includes(

--- a/src/pages/Orders.tsx
+++ b/src/pages/Orders.tsx
@@ -10,6 +10,7 @@ import SingleOrdersPage from "../components/orders/SingleOrdersPage";
 import UnifiedTabPanel from "../components/panelComponents/TabPanel/UnifiedTabPanel";
 import { useDataContext } from "../context/Data.context";
 import { useGeneralContext } from "../context/General.context";
+import { useLocationContext } from "../context/Location.context";
 import { useOrderContext } from "../context/Order.context";
 import { useUserContext } from "../context/User.context";
 import {
@@ -20,6 +21,7 @@ import { useKitchenMutations } from "../utils/api/menu/kitchen";
 import { useGetGivenDateOrders } from "../utils/api/order/order";
 import { useGetPanelControlPages } from "../utils/api/panelControl/page";
 import { useGetDisabledConditions } from "../utils/api/panelControl/disabledCondition";
+import { MinimalUser } from "../utils/api/user";
 import { formatDate, parseDate } from "../utils/dateUtil";
 import { getItem } from "../utils/getItem";
 import { isActionDisabled } from "../utils/permissions";
@@ -42,15 +44,30 @@ function Orders() {
   const { t } = useTranslation();
   const currentPageId = "orders";
   const [tabPanelKey, setTabPanelKey] = useState(0);
-  const { kitchens } = useDataContext();
+  const { kitchens, users = [], visits = [] } = useDataContext();
   const pages = useGetPanelControlPages();
   const { user } = useUserContext();
+  const { selectedLocationId } = useLocationContext();
   const { mutate: updateKitchenCategory } = useUpdateKitchenCategoryMutation();
   const { updateKitchen } = useKitchenMutations();
   const categories = useGetAllCategories();
   const { todaysOrderDate, setTodaysOrderDate } = useOrderContext();
   const orders = useGetGivenDateOrders();
   const disabledConditions = useGetDisabledConditions();
+  const [selectedActionUser, setSelectedActionUser] =
+    useState<MinimalUser | null>(null);
+  const currentActionUser = selectedActionUser || user;
+  const actionUserOptions = useMemo(() => {
+    const activeVisitUsers = (visits ?? [])
+      .filter(
+        (visit) => !visit?.finishHour && visit.location === selectedLocationId
+      )
+      .map((visit) => getItem(visit.user, users))
+      .filter((u): u is MinimalUser => u !== undefined);
+    return user
+      ? [user, ...activeVisitUsers.filter((u) => u._id !== user._id)]
+      : activeVisitUsers;
+  }, [visits, users, selectedLocationId, user]);
   const ordersOrdersDisabledCondition = useMemo(() => {
     return getItem(DisabledConditionEnum.ORDERS_ORDERS, disabledConditions);
   }, [disabledConditions]);
@@ -76,7 +93,10 @@ function Orders() {
       ...(kitchens?.map((kitchen, index) => ({
         number: index,
         label: kitchen.name,
-        content: <SingleOrdersPage kitchen={kitchen} orders={orders} />,
+        content: (
+          <SingleOrdersPage
+            kitchen={kitchen} orders={orders} actionUser={currentActionUser ?? user} />
+        ),
         isDisabled: false,
         kitchen: kitchen,
       })) ?? []),
@@ -106,8 +126,10 @@ function Orders() {
         number: index,
       }));
     setTabs(filteredTabs ?? []);
+  }, [orders, kitchens, pages, user, todaysOrderDate, currentActionUser]);
+  useEffect(() => {
     setTabPanelKey((prev) => prev + 1);
-  }, [orders, kitchens, pages, user, todaysOrderDate]);
+  }, [kitchens, pages, user, todaysOrderDate]);
   const allowedLocations = useMemo(() => {
     return (
       tabs.find((tab) => tab.number === ordersActiveTab)?.kitchen?.locations ||
@@ -193,6 +215,23 @@ function Orders() {
   return (
     <>
       <Header showLocationSelector={true} allowedLocations={allowedLocations} />
+      {actionUserOptions.length > 0 && (
+        <div className="flex flex-row flex-wrap gap-2 px-4 py-2">
+          {actionUserOptions.map((activeUser) => (
+            <a
+              key={activeUser._id}
+              onClick={() => setSelectedActionUser(activeUser)}
+              className={`px-4 py-2 rounded-lg focus:outline-none cursor-pointer font-medium border border-gray-300 ${
+                activeUser._id === currentActionUser?._id
+                  ? "bg-gray-200 hover:bg-gray-300 text-red-300 hover:text-red-500 shadow-md focus:outline-none"
+                  : "bg-white hover:bg-gray-200 text-gray-600 hover:text-red-500"
+              }`}
+            >
+              {activeUser.name}
+            </a>
+          ))}
+        </div>
+      )}
       <UnifiedTabPanel
         key={tabPanelKey}
         tabs={tabs ?? []}


### PR DESCRIPTION
Kafedeki laptopta sürekli 'kasa' hesabı açık olduğu için, çalışanların sipariş hazırlama,teslim etme gibi istatistiklerinin etkilenmemesi adına, bu işlemlerin Siparişler(/orders) sayfasında kendilerini seçerek yapabilmeleri için: 

- /orders sayfasına, OrderPaymentModal'daki gibi aktif visiti olan kullanıcıları butonlar olarak gösteren bir seçici eklendi; ayrıca login olan kullanıcı(bizim örneğimizde default: kasa) da listeye eklendi.
- Seçili kullanıcı, sayfadaki tüm sipariş aksiyonlarına (Confirm, Ready, Served) attribution olarak kaydediliyor (confirmedBy, preparedBy, deliveredBy).
- Ürün kartındaki "İptal" butonu da seçili kullanıcıya atfedilecek şekilde güncellendi (cancelledBy), ama sadece bu sayfadan yapılan iptaller için.
- Ayrıca "Servis Edildi" kolonunda masa bazlı gruplu satırların (açılır/kapanır collapsible) her işlemden sonra (iptal/geri) otomatik kapanma sorunu giderildi; varsayılan açık/kapalı davranışlar korunarak.