### PR TITLE
Manager ve kasa rolündeki kullanıcıların QR okutmadan aktif visit başlatabilmesi

### DIFF
--- a/src/components/tables/ActiveVisitList.tsx
+++ b/src/components/tables/ActiveVisitList.tsx
@@ -24,6 +24,7 @@ import {
   useMiddlemanMutations,
 } from "../../utils/api/middleman";
 import { useGetShifts } from "../../utils/api/shift";
+import { useManagerCheckInOutMutation } from "../../utils/api/visit";
 import { getItem, getRefId } from "../../utils/getItem";
 import { ConfirmationDialog } from "../common/ConfirmationDialog";
 import { InputWithLabelProps } from "../common/InputWithLabel";
@@ -61,6 +62,7 @@ export function ActiveVisitList({
     selectedLocationId
   ) as unknown as Shift[] | undefined;
   const { updateMiddleman } = useMiddlemanMutations();
+  const { mutate: managerCheckInOut } = useManagerCheckInOutMutation();
   const [isScannerOpen, setIsScannerOpen] = useState(false);
   const [middlemanToEnd, setMiddlemanToEnd] = useState<Middleman | null>(null);
 
@@ -72,8 +74,29 @@ export function ActiveVisitList({
     );
   }, [user]);
 
+  // Manager ve Kasa QR okutmadan direkt giriş/çıkış yapabilir
+  const isManagerOrKasa =
+    user?.role?._id === RoleEnum.MANAGER || user?.role?._id === RoleEnum.COUNTER;
+
+  function toggleVisitAsManager() {
+    if (!selectedLocationId) return;
+    managerCheckInOut(selectedLocationId, {
+      onSuccess: (data) => {
+        toast.success(
+          data.action === "entry"
+            ? t("Check-in successful")
+            : t("Check-out successful")
+        );
+      },
+    });
+  }
+
   function handleChipClose(userId: string) {
     if (!isUserActive(userId)) {
+      return;
+    }
+    if (isManagerOrKasa) {
+      toggleVisitAsManager();
       return;
     }
     setIsScannerOpen(true);
@@ -81,6 +104,10 @@ export function ActiveVisitList({
 
   function handleCheckboxChange() {
     if (isDisabledCondition) {
+      return;
+    }
+    if (isManagerOrKasa) {
+      toggleVisitAsManager();
       return;
     }
     setIsScannerOpen(true);

--- a/src/components/tables/ActiveVisitList.tsx
+++ b/src/components/tables/ActiveVisitList.tsx
@@ -62,7 +62,8 @@ export function ActiveVisitList({
     selectedLocationId
   ) as unknown as Shift[] | undefined;
   const { updateMiddleman } = useMiddlemanMutations();
-  const { mutate: managerCheckInOut } = useManagerCheckInOutMutation();
+  const { mutate: managerCheckInOut, isPending: isCheckingInOut } =
+    useManagerCheckInOutMutation();
   const [isScannerOpen, setIsScannerOpen] = useState(false);
   const [middlemanToEnd, setMiddlemanToEnd] = useState<Middleman | null>(null);
 
@@ -79,7 +80,7 @@ export function ActiveVisitList({
     user?.role?._id === RoleEnum.MANAGER || user?.role?._id === RoleEnum.COUNTER;
 
   function toggleVisitAsManager() {
-    if (!selectedLocationId) return;
+    if (!selectedLocationId || isCheckingInOut) return;
     managerCheckInOut(selectedLocationId, {
       onSuccess: (data) => {
         toast.success(

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -1457,6 +1457,7 @@ export enum RoleEnum {
   KITCHEN2,
   KITCHEN3,
   BARCHEF,
+  COUNTER
 }
 
 export enum RoleNameEnum {

--- a/src/utils/api/visit.ts
+++ b/src/utils/api/visit.ts
@@ -177,6 +177,33 @@ export function useQrCheckInOutMutation() {
   });
 }
 
+function managerCheckInOut(location: number): Promise<QrCheckInResult> {
+  return post<{ location: number }, QrCheckInResult>({
+    path: `${Paths.Visits}/manager-toggle`,
+    payload: { location },
+  });
+}
+
+export function useManagerCheckInOutMutation() {
+  const { selectedLocationId } = useLocationContext();
+  const { selectedDate } = useDateContext();
+  const queryClient = useQueryClient();
+  const { t } = useTranslation();
+  return useMutation({
+    mutationFn: managerCheckInOut,
+    onSuccess: () => {
+      queryClient.invalidateQueries({
+        queryKey: [Paths.Visits, selectedLocationId, selectedDate],
+      });
+    },
+    onError: (_err: { response?: { data?: { message?: string } } }) => {
+      const errorMessage =
+        _err?.response?.data?.message || t("An unexpected error occurred");
+      setTimeout(() => toast.error(errorMessage), 200);
+    },
+  });
+}
+
 export function useGetQrCode(location: number, enabled: boolean) {
   return useQuery({
     queryKey: [`${Paths.Visits}/qr/code`, location],


### PR DESCRIPTION
Manager ve Kasa rolündeki kullanıcılar artık kamera açmadan tek tıkla check-in/check-out yapabiliyor; diğer roller eskisi gibi QR okutmaya devam ediyor. Yetki kontrolü hem frontend'de (UX için) hem backend'de (asıl güvenlik için) uygulanıyor.