### PR TITLE
Panele yüklenirken kare formata re-scale edilen resimlerin "orijinal formunun korunarak" upload edilmesi ve görüntülendikleri yerlerin düzenlenmesi

### DIFF
--- a/src/components/imageUpload/ImageUpload.tsx
+++ b/src/components/imageUpload/ImageUpload.tsx
@@ -180,7 +180,7 @@ const ImageUpload = ({ isFolderSelect = true, itemId }: Props) => {
                 <img
                   src={file.preview}
                   alt={file.name}
-                  className="rounded-md border border-gray-200 w-60 h-72 relative"
+                  className="rounded-md border border-gray-200 w-60 h-72 object-contain relative"
                 />
                 <button
                   onClick={() => removeFile(file.name)}

--- a/src/components/orderDatas/DaVinciGameSalesReport.tsx
+++ b/src/components/orderDatas/DaVinciGameSalesReport.tsx
@@ -229,7 +229,7 @@ const DaVinciGameSalesReport = () => {
       { key: t("Product"), isSortable: true },
       { key: t("Quantity"), isSortable: true },
       { key: t("Category"), isSortable: true },
-      { key: t("Unit Price"), isSortable: true },
+      { key: t("Avg. Unit Price"), isSortable: true },
       { key: t("Discount"), isSortable: true },
       { key: t("Total Amount"), isSortable: true },
       { key: t("General Amount"), isSortable: true },
@@ -246,7 +246,7 @@ const DaVinciGameSalesReport = () => {
           row?.item === 0 ? null : (
             <img
               src={row?.imageUrl || NO_IMAGE_URL}
-              alt="img"
+              alt={row?.itemName || "Product"}
               className="w-12 h-12 rounded-full min-w-12"
             />
           ),
@@ -276,13 +276,15 @@ const DaVinciGameSalesReport = () => {
       {
         key: "unitPrice",
         node: (row: OrderWithPaymentInfo) => {
+          const avgUnitPrice =
+            row?.paidQuantity > 0 ? row.amount / row.paidQuantity : 0;
           return (
             <p className={`${row?.className}`} key={"unitPrice" + row?.item}>
-              {row?.unitPriceQuantity.length > 1 || row?.unitPrice === 0
+              {row?.item === 0 || avgUnitPrice === 0
                 ? ""
                 : TURKISHLIRA +
                   " " +
-                  row?.unitPrice?.toFixed(2).replace(/\.?0*$/, "")}
+                  avgUnitPrice.toFixed(2).replace(/\.?0*$/, "")}
             </p>
           );
         },

--- a/src/components/orderDatas/DaVinciGameSalesReport.tsx
+++ b/src/components/orderDatas/DaVinciGameSalesReport.tsx
@@ -5,6 +5,7 @@ import { useMemo } from "react";
 import { useTranslation } from "react-i18next";
 import { useOrderContext } from "../../context/Order.context";
 import { useUserContext } from "../../context/User.context";
+import { NO_IMAGE_URL } from "../../navigation/constants";
 import {
   ActionEnum,
   DateRangeKey,
@@ -52,6 +53,7 @@ type Collapsible = {
 type OrderWithPaymentInfo = {
   item: number;
   itemName: string;
+  imageUrl?: string;
   unitPrice: number;
   paidQuantity: number;
   discount: number;
@@ -152,6 +154,7 @@ const DaVinciGameSalesReport = () => {
           acc.push({
             item: order?.item,
             itemName: menuItem?.name ?? "",
+            imageUrl: menuItem?.imageUrl,
             unitPrice: order?.unitPrice,
             paidQuantity: orderQuantity,
             discount: discountAmount,
@@ -222,6 +225,7 @@ const DaVinciGameSalesReport = () => {
 
   const columns = useMemo(
     () => [
+      { key: "", isSortable: false },
       { key: t("Product"), isSortable: true },
       { key: t("Quantity"), isSortable: true },
       { key: t("Category"), isSortable: true },
@@ -235,6 +239,18 @@ const DaVinciGameSalesReport = () => {
 
   const rowKeys = useMemo(
     () => [
+      {
+        key: "imageUrl",
+        isImage: true,
+        node: (row: OrderWithPaymentInfo) =>
+          row?.item === 0 ? null : (
+            <img
+              src={row?.imageUrl || NO_IMAGE_URL}
+              alt="img"
+              className="w-12 h-12 rounded-full min-w-12"
+            />
+          ),
+      },
       {
         key: "itemName",
         className: "min-w-fit pr-2",
@@ -583,6 +599,7 @@ const DaVinciGameSalesReport = () => {
           title={t("Product Sales (Da Vinci)")}
           isActionsActive={false}
           isCollapsible={true}
+          imageHolder={NO_IMAGE_URL}
         />
       </div>
     </>

--- a/src/components/panelComponents/FormElements/GenericAddEditPanel.tsx
+++ b/src/components/panelComponents/FormElements/GenericAddEditPanel.tsx
@@ -515,7 +515,7 @@ const GenericAddEditPanel = <T,>({
                         <img
                           src={formElements[input.formKey]}
                           alt="image"
-                          className="block h-full w-full object-cover"
+                          className="block h-full w-full object-contain"
                         />
                         <div className="absolute inset-0 flex items-center justify-center bg-black/45 opacity-0 transition-opacity group-hover:opacity-100">
                           <div className="flex flex-col items-center gap-1 text-white">

--- a/src/components/panelComponents/FormElements/TabInputScreen.tsx
+++ b/src/components/panelComponents/FormElements/TabInputScreen.tsx
@@ -214,7 +214,7 @@ const TabInputScreen = ({
                     <img
                       src={opt.imageUrl}
                       alt={opt.label}
-                      className="w-16 h-16 object-cover rounded-md hidden sm:block"
+                      className="w-16 h-16 object-contain rounded-md border border-gray-300 hidden sm:block"
                     />
                   )}
                   <span className="text-gray-800 text-center">{opt.label}</span>

--- a/src/locales/en/translation.json
+++ b/src/locales/en/translation.json
@@ -1392,6 +1392,7 @@
   "First Entry": "First Entry",
   "Last Entry": "Last Entry",
   "Unit Price": "Unit Price",
+  "Avg. Unit Price": "Avg. Unit Price",
   "Menu Item": "Menu Item",
   "Stock Histories Reports": "Stock Histories Reports",
   "panel": "Panel",

--- a/src/locales/tr/translation.json
+++ b/src/locales/tr/translation.json
@@ -722,6 +722,7 @@
   "First Entry": "İlk Giriş",
   "Last Entry": "Son Giriş",
   "Unit Price": "Birim Fiyat",
+  "Avg. Unit Price": "Ort. Birim Fiyat",
   "Menu Item": "Menü Öğesi",
   "Stock Histories Reports": "Stok Geçmiş Raporları",
   "Active Table": "Aktif Masa",

--- a/src/pages/SingleFolderPage.tsx
+++ b/src/pages/SingleFolderPage.tsx
@@ -67,7 +67,7 @@ function SingleFolderPage() {
                 <img
                   src={image.url}
                   alt={image.publicId}
-                  className="w-full h-32 object-cover rounded-md"
+                  className="w-full h-32 object-contain rounded-md"
                 />
                 {/* content */}
                 <div className="flex flex-col gap-2">


### PR DESCRIPTION
- Projenin farklı yerlerinde upload edilen/edilecek resimlerin önizlemelerinin kare çerçeve içinde orijinal formunda görüntülenmesi sağlandı.
- Sipariş oluşturma ekranında da - önceki maddede bahsedilen - bir önceki maddede bahsedilen uygulamaya geçildi. (Erdem abi böyle rica etmişti.)
- "Sipariş Verileri"(/order-datas) sayfasına Da Vinci Oyunlarının satışını takip etmek için yeni eklediğimiz DaVinciGameSalesReport.tsx sayfasına ürün resimleri eklendi. (Bu istenmemişti ama güzel duracağını düşünerek ben ekledim, uygun değilse çıkarabiliriz)