### PR TITLE
VisitScheduleOverview sayfasında API isteği hatası ve çeviri eksikliklerinin giderilmesi

### DIFF
--- a/src/components/visits/VisitScheduleOverview.tsx
+++ b/src/components/visits/VisitScheduleOverview.tsx
@@ -165,8 +165,8 @@ const VisitScheduleOverview = () => {
   const columns = useMemo(
     () => [
       { key: t("User"), isSortable: true, correspondingKey: "userName" },
-      { key: "Part Time", isSortable: true, correspondingKey: "partTime" },
-      { key: "Full Time", isSortable: true, correspondingKey: "fullTime" },
+      { key: t("Part Time"), isSortable: true, correspondingKey: "partTime" },
+      { key: t("Full Time"), isSortable: true, correspondingKey: "fullTime" },
       {
         key: t("Wrong Entry"),
         isSortable: true,

--- a/src/components/visits/VisitScheduleOverview.tsx
+++ b/src/components/visits/VisitScheduleOverview.tsx
@@ -165,8 +165,8 @@ const VisitScheduleOverview = () => {
   const columns = useMemo(
     () => [
       { key: t("User"), isSortable: true, correspondingKey: "userName" },
-      { key: t("Part Time"), isSortable: true, correspondingKey: "partTime" },
-      { key: t("Full Time"), isSortable: true, correspondingKey: "fullTime" },
+      { key: t("parttime"), isSortable: true, correspondingKey: "partTime" },
+      { key: t("fulltime"), isSortable: true, correspondingKey: "fullTime" },
       {
         key: t("Wrong Entry"),
         isSortable: true,

--- a/src/locales/en/translation.json
+++ b/src/locales/en/translation.json
@@ -1747,9 +1747,7 @@
   "Order marked as shipped": "Order marked as shipped",
   "Order marked as unshipped": "Order marked as unshipped",
   "Item updated successfully": "Item updated successfully",
-  "Wrong Entry": "Wrong Entry",
-  "Full Time": "Full Time",
-  "Part Time": "Part Time"
+  "Wrong Entry": "Wrong Entry"
 
 
 }

--- a/src/locales/en/translation.json
+++ b/src/locales/en/translation.json
@@ -1746,7 +1746,10 @@
   "Selected item has unshipped pre-orders": "Selected item has unshipped pre-orders",
   "Order marked as shipped": "Order marked as shipped",
   "Order marked as unshipped": "Order marked as unshipped",
-  "Item updated successfully": "Item updated successfully"
+  "Item updated successfully": "Item updated successfully",
+  "Wrong Entry": "Wrong Entry",
+  "Full Time": "Full Time",
+  "Part Time": "Part Time"
 
 
 }

--- a/src/locales/tr/translation.json
+++ b/src/locales/tr/translation.json
@@ -1755,5 +1755,8 @@
   "Selected item has unshipped pre-orders": "Seçili öğe, henüz gönderilmemiş ön siparişler içeriyor.",
   "Order marked as shipped": "Sipariş gönderildi olarak işaretlendi",
   "Order marked as unshipped": "Sipariş gönderilmedi olarak işaretlendi",
-  "Item updated successfully": "Ürün başarıyla güncellendi"
+  "Item updated successfully": "Ürün başarıyla güncellendi",
+  "Wrong Entry": "Hatalı Giriş",
+  "Full Time": "Tam Zamanlı",
+  "Part Time": "Yarı Zamanlı"
 }

--- a/src/locales/tr/translation.json
+++ b/src/locales/tr/translation.json
@@ -1756,7 +1756,5 @@
   "Order marked as shipped": "Sipariş gönderildi olarak işaretlendi",
   "Order marked as unshipped": "Sipariş gönderilmedi olarak işaretlendi",
   "Item updated successfully": "Ürün başarıyla güncellendi",
-  "Wrong Entry": "Hatalı Giriş",
-  "Full Time": "Tam Zamanlı",
-  "Part Time": "Yarı Zamanlı"
+  "Wrong Entry": "Hatalı Giriş"
 }

--- a/src/utils/api/shift.ts
+++ b/src/utils/api/shift.ts
@@ -74,8 +74,8 @@ export function useGetUserShifts(
   if (before) {
     url = url.concat(`&before=${before}`);
   }
-  if (location) {
-    url = url.concat(`&location=${location}`);
+  if (user) {
+    url = url.concat(`&user=${user}`);
   }
   return useGetList<Shift>(url, [`${Paths.Shift}`, after, before, user], true);
 }


### PR DESCRIPTION
- useGetUserShifts fonksiyonunda global window.location nesnesi yanlışlıkla sorgu parametresi olarak kullanılıyordu; bu durum API isteklerinde &location=<sayfa URL'si> şeklinde geçersiz bir parametre oluşturuyordu. if (location) → if (user) ve &location= → &user= olarak düzeltildi.
- VisitScheduleOverview bileşeninde "Part Time" ve "Full Time" kolon başlıkları t() fonksiyonuna alınarak çeviri desteği eklendi.
- İngilizce ve Türkçe çeviri dosyalarına "Part Time", "Full Time" ve "Wrong Entry" anahtarları eklendi (Yarı Zamanlı, Tam Zamanlı, Hatalı Giriş).