### PR TITLE
Sayımda miktar girilince tüm liste yerine sadece o ürün gönderiliyor

### DIFF
--- a/src/pages/Count.tsx
+++ b/src/pages/Count.tsx
@@ -304,7 +304,6 @@ const Count = () => {
                   productDeleteRequest: row?.productDeleteRequest
                     ? ""
                     : user._id,
-                  currentProducts: currentCount.products || [],
                 });
               }}
             >
@@ -395,7 +394,6 @@ const Count = () => {
                     productId: rowProduct._id,
                     countQuantity: Number(value),
                     stockQuantity: productStock?.quantity || 0,
-                    currentProducts: currentCount.products || [],
                   });
                 }}
                 isDebounce={true}

--- a/src/utils/api/account/count.ts
+++ b/src/utils/api/account/count.ts
@@ -16,13 +16,6 @@ interface UpdateCountQuantityPayload {
   countQuantity: number;
   stockQuantity: number;
   productDeleteRequest?: string;
-  currentProducts: {
-    product: string;
-    stockQuantity: number;
-    countQuantity: number;
-    isStockEqualized?: boolean;
-    productDeleteRequest?: string;
-  }[];
 }
 export interface CountsPayload {
   data: AccountCount[];
@@ -179,25 +172,15 @@ export const updateCountQuantity = (payload: UpdateCountQuantityPayload) => {
     countQuantity,
     stockQuantity,
     productDeleteRequest,
-    currentProducts,
   } = payload;
 
-  // Build the new products array just like the old version
-  const newProducts = [
-    ...(currentProducts?.filter((p) => p.product !== productId) || []),
-    {
+  return patch({
+    path: `${Paths.Accounting}/counts/${countId}/product`,
+    payload: {
       product: productId,
       countQuantity,
       stockQuantity,
       productDeleteRequest,
-    },
-  ];
-
-  return patch({
-    path: `${Paths.Accounting}/counts/${countId}`,
-    payload: {
-      products: newProducts,
-      isCompleted: false,
     },
   });
 };


### PR DESCRIPTION
updateCountQuantity her girişte cache'teki listeden yeni bir products dizisi kurup gönderiyordu. Cache güncel değilse dizi eksik oluyor ve sunucuda daha önce girilmiş miktarları siliyordu; mesela turk_kahvesi_500gr'a girilen 6, filtre_kahve_250gr yazılırken kayboluyordu.

Backend'e bunun için PATCH /counts/:id/product endpoint'ini ekledik, artık sadece sayılan ürün gönderiliyor. Böylece dizi kurma mantığına ve currentProducts alanına gerek kalmadı, ikisini de sildim.