### PR TITLE
fix: sidebar'da menü açılınca scroll'un yukarı zıplaması giderildi

### DIFF
--- a/src/components/common/Sidebar.tsx
+++ b/src/components/common/Sidebar.tsx
@@ -62,7 +62,7 @@ export const Sidebar = () => {
     if (!isSidebarOpen) {
       setIsSidebarOpen(true);
     } else {
-      searchInputRef.current?.focus();
+      searchInputRef.current?.focus({ preventScroll: true });
     }
   });
 
@@ -161,7 +161,7 @@ export const Sidebar = () => {
     }
 
     if (isSidebarOpen) {
-      searchInputRef.current?.focus();
+      searchInputRef.current?.focus({ preventScroll: true });
     } else {
       setOpenGroups({});
     }

--- a/src/components/panelComponents/FormElements/AutocompleteInput.tsx
+++ b/src/components/panelComponents/FormElements/AutocompleteInput.tsx
@@ -41,7 +41,7 @@ const getOptionLabel = (option: string | { value: string; label?: string }) =>
   typeof option === "string" ? option : option.label ?? option.value;
 
 export type AutocompleteInputHandle = {
-  focus: () => void;
+  focus: (options?: FocusOptions) => void;
 };
 
 const AutocompleteInput = forwardRef<AutocompleteInputHandle, AutocompleteInputProps>(({
@@ -70,7 +70,7 @@ const AutocompleteInput = forwardRef<AutocompleteInputHandle, AutocompleteInputP
   const inputRef = useRef<HTMLInputElement>(null);
 
   useImperativeHandle(ref, () => ({
-    focus: () => inputRef.current?.focus(),
+    focus: (options?: FocusOptions) => inputRef.current?.focus(options),
   }));
 
   const containerRef = useRef<HTMLDivElement>(null);


### PR DESCRIPTION
isSidebarOpen true olduğunda arama kutusuna verilen focus, sidebar'ın overflow konteynerini en üste kaydırıyordu. focus çağrılarına preventScroll: true eklenerek scroll pozisyonu korunuyor.