### PR TITLE
feat: Ziyaretler ve Ön Siparişler sayfalarına hızlı tarih filtresi eklendi

### DIFF
--- a/src/components/orderDatas/PreOrders.tsx
+++ b/src/components/orderDatas/PreOrders.tsx
@@ -6,6 +6,7 @@ import {
   MdOutlineCheckBox,
   MdOutlineCheckBoxOutlineBlank,
 } from "react-icons/md";
+import { QuickDateRangeFilter } from "../common/QuickDateRangeFilter";
 import GenericTable from "../panelComponents/Tables/GenericTable";
 import ButtonFilter from "../panelComponents/common/ButtonFilter";
 import SwitchButton from "../panelComponents/common/SwitchButton";
@@ -348,6 +349,26 @@ const PreOrders = () => {
   const filters = useMemo(
     () => [
       {
+        isUpperSide: true,
+        node: (
+          <QuickDateRangeFilter
+            startDate={preOrderFilterPanelFormElements.after}
+            endDate={preOrderFilterPanelFormElements.before}
+            onChange={(start: string, end: string) => {
+              const isReset = !start && !end;
+              setPreOrderFilterPanelFormElements({
+                ...preOrderFilterPanelFormElements,
+                after: isReset
+                  ? initialPreOrderFilterPanelFormElements.after
+                  : start,
+                before: isReset ? "" : end,
+                date: "",
+              });
+            }}
+          />
+        ),
+      },
+      {
         isUpperSide: false,
         node: (
           <ButtonFilter
@@ -392,6 +413,9 @@ const PreOrders = () => {
       setShowUnshippedOnly,
       showOrderDataFilters,
       setShowOrderDataFilters,
+      preOrderFilterPanelFormElements,
+      setPreOrderFilterPanelFormElements,
+      initialPreOrderFilterPanelFormElements,
     ]
   );
 

--- a/src/components/visits/AllBreaks.tsx
+++ b/src/components/visits/AllBreaks.tsx
@@ -13,6 +13,7 @@ import { useGetStoreLocations } from "../../utils/api/location";
 import { useGetUsersMinimal } from "../../utils/api/user";
 import { formatAsLocalDate } from "../../utils/format";
 import { getItem } from "../../utils/getItem";
+import { QuickDateRangeFilter } from "../common/QuickDateRangeFilter";
 import GenericTable from "../panelComponents/Tables/GenericTable";
 import SwitchButton from "../panelComponents/common/SwitchButton";
 import { InputTypes } from "../panelComponents/shared/types";
@@ -253,12 +254,36 @@ const AllBreaks = () => {
   const filters = useMemo(
     () => [
       {
+        isUpperSide: true,
+        node: (
+          <QuickDateRangeFilter
+            startDate={filterPanelFormElements.after}
+            endDate={filterPanelFormElements.before}
+            onChange={(start: string, end: string) => {
+              const isReset = !start && !end;
+              setFilterPanelFormElements({
+                ...filterPanelFormElements,
+                after: isReset ? initialFilterPanelFormElements.after : start,
+                before: isReset ? "" : end,
+                date: "",
+              });
+            }}
+          />
+        ),
+      },
+      {
         label: t("Show Filters"),
         isUpperSide: true,
         node: <SwitchButton checked={showFilters} onChange={setShowFilters} />,
       },
     ],
-    [t, showFilters]
+    [
+      t,
+      showFilters,
+      filterPanelFormElements,
+      setFilterPanelFormElements,
+      initialFilterPanelFormElements,
+    ]
   );
 
   const outsideSort = useMemo(

--- a/src/components/visits/AllGameplayTime.tsx
+++ b/src/components/visits/AllGameplayTime.tsx
@@ -14,6 +14,7 @@ import { useGetStoreLocations } from "../../utils/api/location";
 import { useGetUsersMinimal } from "../../utils/api/user";
 import { formatAsLocalDate } from "../../utils/format";
 import { getItem } from "../../utils/getItem";
+import { QuickDateRangeFilter } from "../common/QuickDateRangeFilter";
 import GenericTable from "../panelComponents/Tables/GenericTable";
 import SwitchButton from "../panelComponents/common/SwitchButton";
 import { InputTypes } from "../panelComponents/shared/types";
@@ -292,12 +293,36 @@ const AllGameplayTime = () => {
   const filters = useMemo(
     () => [
       {
+        isUpperSide: true,
+        node: (
+          <QuickDateRangeFilter
+            startDate={filterPanelFormElements.after}
+            endDate={filterPanelFormElements.before}
+            onChange={(start: string, end: string) => {
+              const isReset = !start && !end;
+              setFilterPanelFormElements({
+                ...filterPanelFormElements,
+                after: isReset ? initialFilterPanelFormElements.after : start,
+                before: isReset ? "" : end,
+                date: "",
+              });
+            }}
+          />
+        ),
+      },
+      {
         label: t("Show Filters"),
         isUpperSide: true,
         node: <SwitchButton checked={showFilters} onChange={setShowFilters} />,
       },
     ],
-    [t, showFilters]
+    [
+      t,
+      showFilters,
+      filterPanelFormElements,
+      setFilterPanelFormElements,
+      initialFilterPanelFormElements,
+    ]
   );
 
   const outsideSort = useMemo(

--- a/src/components/visits/AllVisits.tsx
+++ b/src/components/visits/AllVisits.tsx
@@ -18,6 +18,7 @@ import { useGetFilteredVisits, useVisitMutation } from "../../utils/api/visit";
 import { convertDateFormat } from "../../utils/format";
 import { getItem } from "../../utils/getItem";
 import { ConfirmationDialog } from "../common/ConfirmationDialog";
+import { QuickDateRangeFilter } from "../common/QuickDateRangeFilter";
 import GenericTable from "../panelComponents/Tables/GenericTable";
 import SwitchButton from "../panelComponents/common/SwitchButton";
 import { InputTypes } from "../panelComponents/shared/types";
@@ -152,6 +153,24 @@ const AllVisits = () => {
   const filters = useMemo(
     () => [
       {
+        isUpperSide: true,
+        node: (
+          <QuickDateRangeFilter
+            startDate={filterAllVisitsPanelFormElements.after}
+            endDate={filterAllVisitsPanelFormElements.before}
+            onChange={(start: string, end: string) => {
+              const isReset = !start && !end;
+              setFilterAllVisitsPanelFormElements({
+                ...filterAllVisitsPanelFormElements,
+                after: isReset ? initialFilterPanelFormElements.after : start,
+                before: isReset ? "" : end,
+                date: "",
+              });
+            }}
+          />
+        ),
+      },
+      {
         label: t("Show Filters"),
         isUpperSide: true,
         node: (
@@ -164,7 +183,14 @@ const AllVisits = () => {
         ),
       },
     ],
-    [t, showAllVisitsFilters, setShowAllVisitsFilters]
+    [
+      t,
+      showAllVisitsFilters,
+      setShowAllVisitsFilters,
+      filterAllVisitsPanelFormElements,
+      setFilterAllVisitsPanelFormElements,
+      initialFilterPanelFormElements,
+    ]
   );
 
   const actions = useMemo(


### PR DESCRIPTION


Tüm Ziyaretler, Tüm Molalar, Tüm Oyun Süreleri ve Shopify Ön Siparişler sayfalarına QuickDateRangeFilter bileşeni eklendi.