### PR TITLE
Shopify siparişleri sipariş bazında gruplandı

### DIFF
--- a/src/components/orderDatas/ShopifyOrders.tsx
+++ b/src/components/orderDatas/ShopifyOrders.tsx
@@ -12,6 +12,7 @@ import {
   ActionEnum,
   DateRangeKey,
   DisabledConditionEnum,
+  Order,
   OrderStatus,
   Table,
   commonDateOptions,
@@ -52,6 +53,49 @@ const formatShopifyAddress = (address?: {
     .join(", ");
 };
 
+type ShopifyOrderRow = Omit<
+  Order,
+  "_id" | "createdAt" | "cancelledAt" | "item" | "location" | "quantity"
+> & {
+  _id: number | string; // Override: number -> number | string (for "total" row)
+  createdAt: string; // Override: Date -> string (formatted)
+  cancelledAt: string; // Override: Date -> string (formatted)
+  item: string; // Override: number (id) -> string (name)
+  location: string; // Override: number (id) -> string (name)
+  quantity: number | string;
+  date: string;
+  formattedDate: string;
+  createdHour: string;
+  createdByUserId: string;
+  preparedByUserId: string;
+  preparationTime: string;
+  cancelledByUserId: string;
+  deliveryTime: string;
+  discountId: number | string;
+  discountName: string;
+  locationId: number | string;
+  tableId: number | string;
+  tableName: string;
+  amount: number;
+  statusLabel?: string;
+  itemNames?: string;
+  className?: string;
+  isSortable?: boolean;
+  collapsible?: {
+    collapsibleHeader: string;
+    collapsibleColumns: {
+      key: string;
+      isSortable: boolean;
+      className?: string;
+    }[];
+    collapsibleRows: ShopifyOrderRow[];
+    collapsibleRowKeys: {
+      key: string;
+      node?: (row: ShopifyOrderRow) => React.ReactNode;
+    }[];
+  };
+};
+
 const ShopifyOrders = () => {
   const { t } = useTranslation();
   const orders = useGetOrders();
@@ -63,8 +107,7 @@ const ShopifyOrders = () => {
   const discounts = useGetOrderDiscounts();
   const { mutate: cancelShopifyOrder } = useCancelShopifyOrderMutation();
   const [cancelForm, setCancelForm] = useState({ quantity: 1 });
-  const [showShopifyExtraColumns, setShowShopifyExtraColumns] =
-    useState(false);
+  const [showShopifyExtraColumns, setShowShopifyExtraColumns] = useState(false);
   const [isOrderPaymentModalOpen, setIsOrderPaymentModalOpen] = useState(false);
   const { setExpandedRows } = useGeneralContext();
   const { resetOrderContext } = useOrderContext();
@@ -89,7 +132,7 @@ const ShopifyOrders = () => {
     );
   }, [disabledConditions]);
 
-  const rows = useMemo(() => {
+  const flatRows = useMemo((): ShopifyOrderRow[] => {
     if (!orders || !sellLocations || !users || !discounts) {
       return [];
     }
@@ -111,7 +154,7 @@ const ShopifyOrders = () => {
           return true;
         }
       })
-      ?.map((order) => {
+      ?.map((order): ShopifyOrderRow | null => {
         if (!order || !order?.createdAt) {
           return null;
         }
@@ -176,7 +219,7 @@ const ShopifyOrders = () => {
           )?.label,
         };
       })
-      ?.filter((item) => item !== null);
+      ?.filter((item): item is ShopifyOrderRow => item !== null);
 
     const totalRow = {
       _id: "total",
@@ -212,6 +255,112 @@ const ShopifyOrders = () => {
     user,
   ]);
 
+  const rows = useMemo((): ShopifyOrderRow[] => {
+    const totalRow = flatRows?.find((row) => row?._id === "total");
+    const groups = new Map<string, ShopifyOrderRow[]>();
+    flatRows
+      ?.filter((row) => row?._id !== "total")
+      ?.forEach((row) => {
+        const key = row?.shopifyOrderId as string;
+        const group = groups.get(key);
+        if (group) {
+          group.push(row);
+        } else {
+          groups.set(key, [row]);
+        }
+      });
+
+    const summarize = (values: string[]) => {
+      const filled = values.filter(Boolean);
+      const unique = Array.from(new Set(filled));
+      if (filled.length === 0) return "";
+      if (unique.length === 1 && filled.length === values.length) {
+        return unique[0];
+      }
+      return `${filled.length}/${values.length}`;
+    };
+
+    const groupedRows: ShopifyOrderRow[] = Array.from(groups.values()).map(
+      (groupOrders) => {
+        const first = groupOrders[0];
+        const statusLabels = Array.from(
+          new Set(groupOrders.map((order) => order.statusLabel).filter(Boolean))
+        );
+        return {
+          ...first,
+          item:
+            groupOrders.length === 1
+              ? first.item
+              : `${groupOrders.length} ${t("items")}`,
+          itemNames: groupOrders.map((order) => order.item).join(", "),
+          quantity: groupOrders.reduce(
+            (acc, order) => acc + Number(order.quantity),
+            0
+          ),
+          amount: groupOrders.reduce((acc, order) => acc + order.amount, 0),
+          isReturned: groupOrders.some((order) => order.isReturned),
+          cancelledAt: summarize(groupOrders.map((order) => order.cancelledAt)),
+          cancelledBy: summarize(groupOrders.map((order) => order.cancelledBy)),
+          statusLabel: statusLabels.join(", "),
+          collapsible: {
+            collapsibleHeader: t("Products"),
+            collapsibleColumns: [
+              { key: t("Product"), isSortable: false },
+              { key: t("Quantity"), isSortable: false },
+              { key: t("Unit Price"), isSortable: false },
+              { key: t("Amount"), isSortable: false },
+              { key: t("Cancelled At"), isSortable: false },
+              { key: t("Cancelled By"), isSortable: false },
+              { key: t("Status"), isSortable: false },
+              {
+                key: t("Actions"),
+                isSortable: false,
+                className: "text-center",
+              },
+            ],
+            collapsibleRows: groupOrders,
+            collapsibleRowKeys: [
+              { key: "item" },
+              { key: "quantity" },
+              {
+                key: "unitPrice",
+                node: (row: ShopifyOrderRow) => (
+                  <p key={row._id + "unitPrice"}>
+                    {row.unitPrice.toFixed(2).replace(/\.?0*$/, "")} ₺
+                  </p>
+                ),
+              },
+              {
+                key: "amount",
+                node: (row: ShopifyOrderRow) => (
+                  <p key={row._id + "amount"}>
+                    {row.amount.toFixed(2).replace(/\.?0*$/, "")} ₺
+                  </p>
+                ),
+              },
+              { key: "cancelledAt" },
+              { key: "cancelledBy" },
+              { key: "statusLabel" },
+            ],
+          },
+        };
+      }
+    );
+
+    if (totalRow) {
+      groupedRows.unshift({
+        ...totalRow,
+        collapsible: {
+          collapsibleHeader: "",
+          collapsibleColumns: [],
+          collapsibleRows: [],
+          collapsibleRowKeys: [],
+        },
+      });
+    }
+    return groupedRows;
+  }, [flatRows, t]);
+
   const columns = useMemo(
     () => [
       { key: t("Date"), isSortable: true, correspondingKey: "formattedDate" },
@@ -241,7 +390,11 @@ const ShopifyOrders = () => {
       },
       { key: t("Location"), isSortable: true, correspondingKey: "location" },
       { key: t("Retailer"), isSortable: true, correspondingKey: "retailer" },
-      { key: t("Pick Up"), isSortable: true, correspondingKey: "isShopifyPickUp" },
+      {
+        key: t("Pick Up"),
+        isSortable: true,
+        correspondingKey: "isShopifyPickUp",
+      },
       ...(showShopifyExtraColumns
         ? [
             {
@@ -260,7 +413,6 @@ const ShopifyOrders = () => {
           ]
         : []),
       { key: t("Status"), isSortable: true, correspondingKey: "statusLabel" },
-      { key: t("Actions"), isSortable: false },
     ],
     [t, showShopifyExtraColumns]
   );
@@ -366,6 +518,11 @@ const ShopifyOrders = () => {
       { key: "statusLabel", className: "min-w-32 pr-2" },
     ],
     [showShopifyExtraColumns]
+  );
+
+  const searchRowKeys = useMemo(
+    () => [...rowKeys, { key: "itemNames" }],
+    [rowKeys]
   );
 
   const cancelInputs = useMemo(
@@ -680,7 +837,7 @@ const ShopifyOrders = () => {
     ]
   );
 
-  const actions = useMemo(
+  const collapsibleActions = useMemo(
     () => [
       {
         name: t("Cancel"),
@@ -747,18 +904,28 @@ const ShopifyOrders = () => {
           rowKeys={rowKeys}
           rows={rows}
           isActionsActive={true}
-          actions={actions}
+          collapsibleActions={collapsibleActions}
+          isCollapsible={true}
+          searchRowKeys={searchRowKeys}
           filterPanel={filterPanel}
           filters={filters}
           isExcel={
-            !isActionDisabled(shopifyOrdersPageDisabledCondition, ActionEnum.EXCEL, user)
+            !isActionDisabled(
+              shopifyOrdersPageDisabledCondition,
+              ActionEnum.EXCEL,
+              user
+            )
           }
           excelFileName={t("ShopifyOrders.xlsx")}
+          excelRows={flatRows}
           rowClassNameFunction={(row: any) => {
             if (row?.isReturned) {
               return "bg-red-200";
             }
-            if (row?.taxNumberCompanyName && row?.taxNumberCompanyName !== "-") {
+            if (
+              row?.taxNumberCompanyName &&
+              row?.taxNumberCompanyName !== "-"
+            ) {
               return "bg-yellow-100";
             }
             return "";

--- a/src/components/panelComponents/Tables/GenericTable.tsx
+++ b/src/components/panelComponents/Tables/GenericTable.tsx
@@ -82,6 +82,7 @@ type Props<T> = {
   isCollapsibleCheckActive?: boolean;
   isExcel?: boolean;
   excelFileName?: string;
+  excelRows?: any[];
   pagination?: PaginationProps;
   outsideSortProps?: OutsideSortProps;
   outsideSearchProps?: OutsideSearchProps;
@@ -129,6 +130,7 @@ const GenericTable = <T,>({
   tooltipLimit = 40,
   rowClassNameFunction,
   excelFileName,
+  excelRows,
   rowsPerPageOptions = [
     RowPerPageEnum.FIRST,
     RowPerPageEnum.SECOND,
@@ -418,8 +420,8 @@ const GenericTable = <T,>({
   const generateExcel = () => {
     const workbook = XLSX.utils.book_new();
 
-    if (isCollapsible) {
-      const excelRows: any[] = [];
+    if (isCollapsible && !excelRows) {
+      const collapsibleExcelRows: any[] = [];
 
       sortedRows.forEach((row) => {
         const collapsibleHeader = row?.collapsible?.collapsibleHeader;
@@ -428,11 +430,13 @@ const GenericTable = <T,>({
         const collapsibleRows = row?.collapsible?.collapsibleRows ?? [];
 
         if (collapsibleHeader) {
-          excelRows.push([collapsibleHeader]);
+          collapsibleExcelRows.push([collapsibleHeader]);
         }
 
         if (collapsibleColumns.length > 0) {
-          excelRows.push(collapsibleColumns.map((column: any) => column.key));
+          collapsibleExcelRows.push(
+            collapsibleColumns.map((column: any) => column.key)
+          );
         }
 
         if (collapsibleRows.length > 0) {
@@ -444,27 +448,44 @@ const GenericTable = <T,>({
               if (typeof value === "boolean") return value ? "true" : "false";
               return String(value);
             });
-            excelRows.push(rowData);
+            collapsibleExcelRows.push(rowData);
           });
         }
 
-        excelRows.push([]);
+        collapsibleExcelRows.push([]);
       });
 
-      const worksheet = XLSX.utils.aoa_to_sheet(excelRows);
+      const worksheet = XLSX.utils.aoa_to_sheet(collapsibleExcelRows);
       XLSX.utils.book_append_sheet(workbook, worksheet, "Sheet1");
       XLSX.writeFile(workbook, excelFileName ?? "ExportedData.xlsx");
       return;
     }
 
-    const excelRows: any[] = [];
+    const flatExcelRows: any[] = [];
     const headers = usedColumns
       .filter((column) => column.correspondingKey)
       .map((column) => column.key);
 
-    excelRows.push(headers);
+    flatExcelRows.push(headers);
 
-    const excelAllRows = !isEmtpyExcel ? sortedRows : [];
+    const excelQuery = searchQuery.trimStart().toLocaleLowerCase("tr-TR");
+    const searchedExcelRows =
+      excelRows && isSearch && excelQuery
+        ? excelRows.filter((row) =>
+            (searchRowKeys ?? usedRowKeys).some((rowKey) => {
+              const value = row[rowKey.key as keyof typeof row];
+              if (typeof value === "string")
+                return value.toLocaleLowerCase("tr-TR").includes(excelQuery);
+              if (typeof value === "number")
+                return value.toString().includes(excelQuery);
+              if (typeof value === "boolean")
+                return (value ? "true" : "false").includes(excelQuery);
+              return false;
+            })
+          )
+        : excelRows;
+
+    const excelAllRows = !isEmtpyExcel ? searchedExcelRows ?? sortedRows : [];
     excelAllRows.forEach((row) => {
       const rowData = usedColumns
         .filter((column) => column.correspondingKey)
@@ -474,10 +495,10 @@ const GenericTable = <T,>({
           if (typeof value === "number") return value;
           return String(value);
         });
-      excelRows.push(rowData);
+      flatExcelRows.push(rowData);
     });
 
-    const worksheet = XLSX.utils.aoa_to_sheet(excelRows);
+    const worksheet = XLSX.utils.aoa_to_sheet(flatExcelRows);
     XLSX.utils.book_append_sheet(workbook, worksheet, "Sheet1");
     XLSX.writeFile(workbook, excelFileName ?? "ExportedData.xlsx");
   };

--- a/src/locales/en/translation.json
+++ b/src/locales/en/translation.json
@@ -1757,7 +1757,6 @@
   "Order marked as shipped": "Order marked as shipped",
   "Order marked as unshipped": "Order marked as unshipped",
   "Item updated successfully": "Item updated successfully",
-  "Wrong Entry": "Wrong Entry"
-
-
+  "Wrong Entry": "Wrong Entry",
+  "items": "items"
 }

--- a/src/locales/tr/translation.json
+++ b/src/locales/tr/translation.json
@@ -1765,5 +1765,6 @@
   "Order marked as shipped": "Sipariş gönderildi olarak işaretlendi",
   "Order marked as unshipped": "Sipariş gönderilmedi olarak işaretlendi",
   "Item updated successfully": "Ürün başarıyla güncellendi",
-  "Wrong Entry": "Hatalı Giriş"
+  "Wrong Entry": "Hatalı Giriş",
+  "items": "kalem"
 }


### PR DESCRIPTION
4445 gibi bir sipariş tabloda 7 satır kaplıyordu ve toplam tutarı hiçbir yerde görünmüyordu. Artık her sipariş tek satır, kalemler açılır tabloda; iptal butonu kalem bazlı olduğu için oraya taşındı.

Tablo gruplu hale gelince Excel de otomatik olarak gruplu formata düşüyor, tarih ve sipariş no gibi kolonları hiç yazmıyordu. Bunu engellemek için GenericTable'a opsiyonel excelRows prop'u eklendi; Excel eskisi gibi kalem bazında düz iniyor ve diğer sayfalar etkilenmiyor.